### PR TITLE
fix(database): add duplicate indexes check

### DIFF
--- a/internal/database/dialer/cockroachdb/migration/20231214175145_create_database.sql
+++ b/internal/database/dialer/cockroachdb/migration/20231214175145_create_database.sql
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS "dataset_mirror_posts"
     CONSTRAINT "pk_dataset_mirror_posts" PRIMARY KEY ("id")
     );
 
-CREATE INDEX idx_origin_content_digest ON dataset_mirror_posts (origin_content_digest);
+CREATE INDEX IF NOT EXISTS idx_origin_content_digest ON dataset_mirror_posts (origin_content_digest);
 
 
 -- +goose StatementEnd


### PR DESCRIPTION
Error caused by attempting to create a duplicate index in ‘dataset_mirror_posts’