### PR TITLE
fix: missing telemetry meter endpoint from config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -145,7 +145,7 @@ func setOpenTelemetry(config *config.File) error {
 		}
 
 		go func() {
-			if err := meterServer.Run(); err != nil {
+			if err := meterServer.Run(*observabilityConfig.Metrics); err != nil {
 				zap.L().Error("failed to run telemetry meter server", zap.Error(err))
 			}
 		}()

--- a/internal/telemetry/meter/meter.go
+++ b/internal/telemetry/meter/meter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/naturalselectionlabs/rss3-node/config"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -20,7 +21,7 @@ const (
 )
 
 type Server interface {
-	Run() error
+	Run(config.OpenTelemetryMetricsConfig) error
 }
 
 var _ Server = (*server)(nil)
@@ -29,8 +30,8 @@ type server struct {
 	httpServer *echo.Echo
 }
 
-func (s *server) Run() error {
-	return s.httpServer.Start("")
+func (s *server) Run(config config.OpenTelemetryMetricsConfig) error {
+	return s.httpServer.Start(config.Endpoint)
 }
 
 func New(driver Driver) (Server, error) {


### PR DESCRIPTION
## Summary

missing telemetry meter endpoint from config

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
