### PR TITLE
chore: fix docker push

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,4 +1,4 @@
-name: build & deploy
+name: build & push
 
 on:
   push:
@@ -111,13 +111,13 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          if [ ${{ github.ref }} != 'refs/heads/develop' ]; then
+          if [ ${{ github.event_name }} == 'pull_request' ]; then
             ARGS="--dry-run"
           fi
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'rss3/node@sha256:%s ' *) $ARGS
       - name: Inspect image
-        if: github.ref == 'refs/heads/develop'
+        if: github.event_name != 'pull_request'
         run: |
           docker buildx imagetools inspect rss3/node:${{ steps.meta.outputs.version }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM golang:1.21.4-alpine AS base
+FROM rss3/go-builder AS base
 
 WORKDIR /root/node
-RUN apk add --no-cache git make gcc libc-dev
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=bind,source=go.sum,target=go.sum \
@@ -16,11 +15,9 @@ ENV CGO_ENABLED=0
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     make build
 
-FROM alpine:3.18.4 AS runner
+FROM rss3/go-runtime AS runner
 
 WORKDIR /root/node
-
-RUN apk add --no-cache ca-certificates tzdata
 
 COPY --from=builder /root/node/build/node .
 COPY deploy/config.yaml /etc/rss3/node/config.yaml


### PR DESCRIPTION
## Summary
docker build would be triggered by 
- branch develop
- tags
- pull_request

but `github.ref == 'refs/heads/develop'` only works with branch develop, tags will be skip, set `github.event_name != 'pull_request'` to cover tags event

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No