### PR TITLE
fix: upgrade farcaster url

### DIFF
--- a/deploy/config.yaml
+++ b/deploy/config.yaml
@@ -94,6 +94,8 @@ component:
     - network: farcaster
       worker: farcaster
       endpoint: https://nemes.farcaster.xyz:2281
+      parameters:
+        api_key:
     # arweave
     - network: arweave
       worker: mirror

--- a/internal/engine/source/farcaster/option.go
+++ b/internal/engine/source/farcaster/option.go
@@ -1,0 +1,23 @@
+package farcaster
+
+import (
+	"github.com/rss3-network/node/config"
+)
+
+type Option struct {
+	APIKey *string `json:"api_key" mapstructure:"api_key"`
+}
+
+func NewOption(options *config.Options) (*Option, error) {
+	var instance Option
+
+	if options == nil {
+		return &instance, nil
+	}
+
+	if err := options.Decode(&instance); err != nil {
+		return nil, err
+	}
+
+	return &instance, nil
+}


### PR DESCRIPTION
## Summary
If the Farcaster URL requires an API key, you should include the api_key in the config parameters.

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
