### PR TITLE
fix(source/savm): get receipts by block number not support

### DIFF
--- a/internal/engine/source/ethereum/source.go
+++ b/internal/engine/source/ethereum/source.go
@@ -109,7 +109,7 @@ func (s *source) pollBlocks(ctx context.Context, tasksChan chan<- []engine.Task)
 
 		// handle crossbell, fantom and arbitrum blockchain cause lack of `eth_getBlockReceipts` implementation
 		switch s.config.Network {
-		case filter.NetworkCrossbell, filter.NetworkFantom, filter.NetworkArbitrum:
+		case filter.NetworkCrossbell, filter.NetworkFantom, filter.NetworkArbitrum, filter.NetworkSatoshiVM:
 			receipts, err = s.getBlockReceipts(ctx, block)
 			if err != nil {
 				return fmt.Errorf("get receipts by block number %d: %w", block.Number, err)
@@ -208,7 +208,7 @@ func (s *source) pollLogs(ctx context.Context, tasksChan chan<- []engine.Task) e
 
 			// handle crossbell, fantom and arbitrum blockchain cause lack of `eth_getBlockReceipts` implementation
 			switch s.config.Network {
-			case filter.NetworkCrossbell, filter.NetworkFantom, filter.NetworkArbitrum:
+			case filter.NetworkCrossbell, filter.NetworkFantom, filter.NetworkArbitrum, filter.NetworkSatoshiVM:
 				receipts, err = s.getBlockReceipts(ctx, block)
 				if err != nil {
 					return fmt.Errorf("get receipts by block number %d: %w", block.Number, err)


### PR DESCRIPTION
## Summary

get receipts by block number not support

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No