### PR TITLE
fix: add encountered recently written committed value tx catch logic

### DIFF
--- a/internal/database/dialer/cockroachdb/client.go
+++ b/internal/database/dialer/cockroachdb/client.go
@@ -85,7 +85,7 @@ func (c *client) WithTransaction(ctx context.Context, transactionFunction func(c
 
 	retryIfFunc := func(err error) bool {
 		// https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference#retry_serializable
-		return strings.HasPrefix(err.Error(), "commit transaction: ERROR: restart transaction: TransactionRetryWithProtoRefreshError: TransactionRetryError: retry txn (RETRY_SERIALIZABLE - failed preemptive refresh due to a conflict:")
+		return strings.HasPrefix(err.Error(), "commit transaction: ERROR: restart transaction: TransactionRetryWithProtoRefreshError: TransactionRetryError: retry txn (RETRY_SERIALIZABLE - failed preemptive refresh due to")
 	}
 
 	onRetryFunc := func(n uint, err error) {


### PR DESCRIPTION
## Summary

add encountered recently written committed value tx catch logic

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No