### PR TITLE
perf(source/ethereum): support batch request for ethereum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,13 +77,11 @@ require (
 	github.com/crate-crypto/go-kzg-4844 v0.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deckarep/golang-set/v2 v2.3.1 // indirect
-	github.com/dmarkham/enumer v1.5.9 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v24.0.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
-	github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5il
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
-github.com/dmarkham/enumer v1.5.9 h1:NM/1ma/AUNieHZg74w67GkHFBNB15muOt3sj486QVZk=
-github.com/dmarkham/enumer v1.5.9/go.mod h1:e4VILe2b1nYK3JKJpRmNdl5xbDQvELc6tQ8b+GsGk6E=
 github.com/docker/cli v24.0.7+incompatible h1:wa/nIwYFW7BVTGa7SWPVyyXU9lgORqUb1xfI36MSkFg=
 github.com/docker/cli v24.0.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
@@ -103,8 +101,6 @@ github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/ethereum/go-ethereum v1.13.14 h1:EwiY3FZP94derMCIam1iW4HFVrSgIcpsu0HwTQtm6CQ=
 github.com/ethereum/go-ethereum v1.13.14/go.mod h1:TN8ZiHrdJwSe8Cb6x+p0hs5CxhJZPbqB7hHkaUXcmIU=
-github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e h1:bBLctRc7kr01YGvaDfgLbTwjFNW5jdp5y5rj8XXBHfY=
-github.com/fjl/gencodec v0.0.0-20230517082657-f9840df7b83e/go.mod h1:AzA8Lj6YtixmJWL+wkKoBGsLWy9gFrAzi4g+5bCKwpY=
 github.com/fjl/memsize v0.0.2 h1:27txuSD9or+NZlnOWdKUxeBzTAUkWCVh+4Gf2dWFOzA=
 github.com/fjl/memsize v0.0.2/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -115,8 +111,6 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
-github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 h1:IZqZOB2fydHte3kUgxrzK5E1fW7RQGeDwE8F/ZZnUYc=
-github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46 h1:BAIP2GihuqhwdILrV+7GJel5lyPV3u1+PgzrWLc0TkE=
@@ -321,8 +315,6 @@ github.com/orlangure/gnomock v0.30.0 h1:WXq/3KTKRVYe9a3BXa5JMZCCrg2RwNAPB2bZHMxE
 github.com/orlangure/gnomock v0.30.0/go.mod h1:vDur9icFVsecjDQrHn06SbUs0BXjJaNJRDexBsPh5f4=
 github.com/ory/dockertest/v3 v3.10.0 h1:4K3z2VMe8Woe++invjaTB7VRyQXQy5UY+loujO4aNE4=
 github.com/ory/dockertest/v3 v3.10.0/go.mod h1:nr57ZbRWMqfsdGdFNLHz5jjNdDb7VVFnzAeW1n5N1Lg=
-github.com/pascaldekloe/name v1.0.0 h1:n7LKFgHixETzxpRv2R77YgPUFo85QHGZKrdaYm7eY5U=
-github.com/pascaldekloe/name v1.0.0/go.mod h1:Z//MfYJnH4jVpQ9wkclwu2I2MkHmXTlT9wR5UZScttM=
 github.com/paulmach/orb v0.10.0 h1:guVYVqzxHE/CQ1KpfGO077TR0ATHSNjp4s6XGLn3W9s=
 github.com/paulmach/orb v0.10.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=

--- a/internal/engine/source/ethereum/option.go
+++ b/internal/engine/source/ethereum/option.go
@@ -8,7 +8,10 @@ import (
 )
 
 const (
-	defaultRPCThreadBlocks = uint64(8)
+	defaultRPCThreadBlocks       = uint(8)
+	defaultRPCBatchBlocks        = uint(8)
+	defaultRPCBatchReceipts      = uint(200)
+	defaultRPCBatchBlockReceipts = uint(8)
 )
 
 type Option struct {
@@ -16,7 +19,10 @@ type Option struct {
 	BlockNumberTarget *big.Int `json:"block_number_target" mapstructure:"block_number_target"`
 
 	// RPCThreadBlocks is the number of concurrent RPC requests associated with the blocks.
-	RPCThreadBlocks *uint64 `json:"rpc_thread_blocks" mapstructure:"rpc_thread_blocks"`
+	RPCThreadBlocks       *uint `json:"rpc_thread_blocks" mapstructure:"rpc_thread_blocks"`
+	RPCBatchBlocks        *uint `json:"rpc_batch_blocks" mapstructure:"rpc_batch_blocks"`
+	RPCBatchReceipts      *uint `json:"rpc_batch_receipts" mapstructure:"rpc_batch_blocks"`
+	RPCBatchBlockReceipts *uint `json:"rpc_batch_block_receipts" mapstructure:"rpc_batch_block_receipts"`
 }
 
 func NewOption(options *config.Options) (*Option, error) {
@@ -33,6 +39,18 @@ func NewOption(options *config.Options) (*Option, error) {
 	// Set default values.
 	if instance.RPCThreadBlocks == nil {
 		instance.RPCThreadBlocks = lo.ToPtr(defaultRPCThreadBlocks)
+	}
+
+	if instance.RPCBatchBlocks == nil {
+		instance.RPCBatchBlocks = lo.ToPtr(defaultRPCBatchBlocks)
+	}
+
+	if instance.RPCBatchReceipts == nil {
+		instance.RPCBatchReceipts = lo.ToPtr(defaultRPCBatchReceipts)
+	}
+
+	if instance.RPCBatchBlockReceipts == nil {
+		instance.RPCBatchBlockReceipts = lo.ToPtr(defaultRPCBatchBlockReceipts)
 	}
 
 	return &instance, nil

--- a/internal/engine/source/ethereum/source.go
+++ b/internal/engine/source/ethereum/source.go
@@ -204,7 +204,7 @@ func (s *source) pollLogs(ctx context.Context, tasksChan chan<- *engine.Tasks) e
 			continue
 		}
 
-		blockNumberEnd := min(blockNumberStart+*s.option.RPCThreadBlocks-1, blockNumberLatestRemote)
+		blockNumberEnd := min(blockNumberStart+uint64(*s.option.RPCThreadBlocks)-1, blockNumberLatestRemote)
 
 		span.SetAttributes(
 			attribute.String("block.number.start", strconv.FormatUint(blockNumberStart, 10)),
@@ -306,26 +306,28 @@ func (s *source) pollLogs(ctx context.Context, tasksChan chan<- *engine.Tasks) e
 
 // getBlocks is used to concurrently get blocks by block number.
 func (s *source) getBlocks(ctx context.Context, blockNumbers []*big.Int) ([]*ethereum.Block, error) {
-	resultPool := pool.NewWithResults[*ethereum.Block]().
+	resultPool := pool.NewWithResults[[]*ethereum.Block]().
 		WithContext(ctx).
 		WithFirstError().
 		WithCancelOnError()
 
-	for _, blockNumber := range blockNumbers {
-		blockNumber := blockNumber
+	for _, blockNumbers := range lo.Chunk(blockNumbers, int(*s.option.RPCBatchBlocks)) {
+		blockNumbers := blockNumbers
 
-		resultPool.Go(func(ctx context.Context) (*ethereum.Block, error) {
-			return s.ethereumClient.BlockByNumber(ctx, blockNumber)
+		resultPool.Go(func(ctx context.Context) ([]*ethereum.Block, error) {
+			return s.ethereumClient.BatchBlockByNumbers(ctx, blockNumbers)
 		})
 	}
 
-	blocks, err := resultPool.Wait()
+	batchResults, err := resultPool.Wait()
 	if err != nil {
 		return nil, err
 	}
 
+	blocks := lo.Flatten(batchResults)
+
+	// Sort blocks by block number in ascending order.
 	sort.SliceStable(blocks, func(left, right int) bool {
-		// Sort blocks by block number in ascending order.
 		return blocks[left].Number.Cmp(blocks[right].Number) == -1
 	})
 
@@ -338,8 +340,7 @@ func (s *source) getReceipts(ctx context.Context, blocks []*ethereum.Block) ([]*
 		filter.NetworkCrossbell,
 		filter.NetworkArbitrum,
 		filter.NetworkSatoshiVM,
-		filter.NetworkLinea,
-		filter.NetworkBinanceSmartChain:
+		filter.NetworkLinea:
 		transactionHashes := lo.Map(blocks, func(block *ethereum.Block, _ int) []common.Hash {
 			return lo.Map(block.Transactions, func(transaction *ethereum.Transaction, _ int) common.Hash {
 				return transaction.Hash
@@ -362,37 +363,47 @@ func (s *source) getReceiptsByBlockNumbers(ctx context.Context, blockNumbers []*
 		WithFirstError().
 		WithCancelOnError()
 
-	for _, blockNumber := range blockNumbers {
-		blockNumber := blockNumber
+	for _, blockNumbers := range lo.Chunk(blockNumbers, int(*s.option.RPCBatchBlockReceipts)) {
+		blockNumbers := blockNumbers
 
 		resultPool.Go(func(ctx context.Context) ([]*ethereum.Receipt, error) {
-			return s.ethereumClient.BlockReceipts(ctx, blockNumber)
+			batchReceipts, err := s.ethereumClient.BatchBlockReceipts(ctx, blockNumbers)
+			if err != nil {
+				return nil, err
+			}
+
+			return lo.Flatten(batchReceipts), nil
 		})
 	}
 
-	receipts, err := resultPool.Wait()
+	batchResults, err := resultPool.Wait()
 	if err != nil {
 		return nil, err
 	}
 
-	return lo.Flatten(receipts), nil
+	return lo.Flatten(batchResults), nil
 }
 
 func (s *source) getReceiptsByTransactionHashes(ctx context.Context, transactionHashes []common.Hash) ([]*ethereum.Receipt, error) {
-	resultPool := pool.NewWithResults[*ethereum.Receipt]().
+	resultPool := pool.NewWithResults[[]*ethereum.Receipt]().
 		WithContext(ctx).
 		WithFirstError().
 		WithCancelOnError()
 
-	for _, transactionHash := range transactionHashes {
-		transactionHash := transactionHash
+	for _, transactionHashes := range lo.Chunk(transactionHashes, int(*s.option.RPCBatchBlockReceipts)) {
+		transactionHashes := transactionHashes
 
-		resultPool.Go(func(ctx context.Context) (*ethereum.Receipt, error) {
-			return s.ethereumClient.TransactionReceipt(ctx, transactionHash)
+		resultPool.Go(func(ctx context.Context) ([]*ethereum.Receipt, error) {
+			return s.ethereumClient.BatchTransactionReceipt(ctx, transactionHashes)
 		})
 	}
 
-	return resultPool.Wait()
+	batchResults, err := resultPool.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Flatten(batchResults), nil
 }
 
 func (s *source) buildTasks(block *ethereum.Block, receipts []*ethereum.Receipt) ([]*Task, error) {

--- a/provider/ethereum/client.go
+++ b/provider/ethereum/client.go
@@ -140,7 +140,7 @@ func (c *client) BlockByNumber(ctx context.Context, number *big.Int) (*Block, er
 func (c *client) BatchBlockByNumbers(ctx context.Context, numbers []*big.Int) ([]*Block, error) {
 	batchElements := make([]rpc.BatchElem, 0, len(numbers))
 
-	for _, num := range numbers {
+	for _, number := range numbers {
 		batchElement := rpc.BatchElem{
 			Method: "eth_getBlockByNumber",
 			Args: []any{

--- a/provider/ethereum/client.go
+++ b/provider/ethereum/client.go
@@ -2,6 +2,7 @@ package ethereum
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -9,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/samber/lo"
 )
 
 // Client provides basic RPC methods.
@@ -22,9 +24,12 @@ type Client interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*Header, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*Block, error)
 	BlockByNumber(ctx context.Context, number *big.Int) (*Block, error)
+	BatchBlockByNumbers(ctx context.Context, numbers []*big.Int) ([]*Block, error)
 	BlockReceipts(ctx context.Context, number *big.Int) ([]*Receipt, error)
+	BatchBlockReceipts(ctx context.Context, numbers []*big.Int) ([][]*Receipt, error)
 	TransactionByHash(ctx context.Context, hash common.Hash) (*Transaction, error)
 	TransactionReceipt(ctx context.Context, hash common.Hash) (*Receipt, error)
+	BatchTransactionReceipt(ctx context.Context, hashes []common.Hash) ([]*Receipt, error)
 	StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error)
 	FilterLogs(ctx context.Context, filter Filter) ([]*Log, error)
 }
@@ -131,6 +136,30 @@ func (c *client) BlockByNumber(ctx context.Context, number *big.Int) (*Block, er
 	return block, nil
 }
 
+// BatchBlockByNumbers returns the blocks with the given numbers.
+func (c *client) BatchBlockByNumbers(ctx context.Context, numbers []*big.Int) ([]*Block, error) {
+	batchElements := make([]rpc.BatchElem, 0, len(numbers))
+
+	for _, num := range numbers {
+		batchElement := rpc.BatchElem{
+			Method: "eth_getBlockByNumber",
+			Args: []any{
+				formatBlockNumber(number),
+				true,
+			},
+			Result: new(Block),
+		}
+
+		batchElements = append(batchElements, batchElement)
+	}
+
+	if err := c.rpcClient.BatchCallContext(ctx, batchElements); err != nil {
+		return nil, err
+	}
+
+	return unwrapBatchElements[*Block](batchElements)
+}
+
 // BlockReceipts returns the receipts of a block by block number.
 func (c *client) BlockReceipts(ctx context.Context, number *big.Int) ([]*Receipt, error) {
 	var receipts *[]*Receipt
@@ -143,6 +172,34 @@ func (c *client) BlockReceipts(ctx context.Context, number *big.Int) ([]*Receipt
 	}
 
 	return *receipts, nil
+}
+
+// BatchBlockReceipts returns the receipts of multiple blocks by block numbers.
+func (c *client) BatchBlockReceipts(ctx context.Context, numbers []*big.Int) ([][]*Receipt, error) {
+	batchElements := make([]rpc.BatchElem, 0, len(numbers))
+
+	for _, number := range numbers {
+		batchElement := rpc.BatchElem{
+			Method: "eth_getBlockReceipts",
+			Args: []any{
+				formatBlockNumber(number),
+			},
+			Result: new([]*Receipt),
+		}
+
+		batchElements = append(batchElements, batchElement)
+	}
+
+	if err := c.rpcClient.BatchCallContext(ctx, batchElements); err != nil {
+		return nil, err
+	}
+
+	batchReceipts, err := unwrapBatchElements[*[]*Receipt](batchElements)
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(batchReceipts, func(receipts *[]*Receipt, _ int) []*Receipt { return *receipts }), nil
 }
 
 // TransactionByHash returns the transaction with the given hash.
@@ -163,6 +220,29 @@ func (c *client) TransactionReceipt(ctx context.Context, hash common.Hash) (*Rec
 	}
 
 	return &receipt, nil
+}
+
+// BatchTransactionReceipt returns the receipts of multiple transactions by transaction hashes.
+func (c *client) BatchTransactionReceipt(ctx context.Context, hashes []common.Hash) ([]*Receipt, error) {
+	batchElements := make([]rpc.BatchElem, 0, len(hashes))
+
+	for _, hash := range hashes {
+		batchElement := rpc.BatchElem{
+			Method: "eth_getTransactionReceipt",
+			Args: []any{
+				hash,
+			},
+			Result: new(Receipt),
+		}
+
+		batchElements = append(batchElements, batchElement)
+	}
+
+	if err := c.rpcClient.BatchCallContext(ctx, batchElements); err != nil {
+		return nil, err
+	}
+
+	return unwrapBatchElements[*Receipt](batchElements)
 }
 
 // StorageAt returns the contract storage of the given account.
@@ -197,4 +277,39 @@ func Dial(ctx context.Context, endpoint string) (Client, error) {
 	}
 
 	return &instance, nil
+}
+
+// unwrapBatchElement unwraps the result of a batch call.
+func unwrapBatchElement[T any](batchElement rpc.BatchElem) (T, error) {
+	var empty T // The default value is nil
+
+	if batchElement.Error != nil {
+		return empty, batchElement.Error
+	}
+
+	result, ok := batchElement.Result.(T)
+	if !ok {
+		return empty, fmt.Errorf("invalid type %T", batchElement.Result)
+	}
+
+	return result, nil
+}
+
+// unwrapBatchElements unwraps the results of a batch call.
+func unwrapBatchElements[T any](batchElements []rpc.BatchElem) ([]T, error) {
+	var (
+		empty   []T // The default value is nil
+		results = make([]T, 0, len(batchElements))
+	)
+
+	for _, batchElement := range batchElements {
+		result, err := unwrapBatchElement[T](batchElement)
+		if err != nil {
+			return empty, err
+		}
+
+		results = append(results, result)
+	}
+
+	return results, nil
 }


### PR DESCRIPTION
## Summary

The concurrency of HTTP requests has been reduced now. If a chain does not support the `eth_getBlockReceipts` method, there are **200** transactions for each of the **8** blocks. The source needs to send **1608** `8 (eth_getBlockByNumber) + 8 * 200 (eth_getTransactionReceipts)` HTTP requests. Now with the default parameters, it only needs **9** `1 (batch size of 8 for eth_getBlockByNumber) + 8 (batch size of 200 for eth_getTransactionReceipts)` HTTP requests.

The Binance Smart Chain also supports the `eth_getBlockReceipts` method, so it was removed from the list.

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [ ] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
