### PR TITLE
perf(source/ethereum): avoid allocating too many duplicate large slice

### DIFF
--- a/internal/engine/source/ethereum/source.go
+++ b/internal/engine/source/ethereum/source.go
@@ -407,7 +407,10 @@ func (s *source) getReceiptsByTransactionHashes(ctx context.Context, transaction
 }
 
 func (s *source) buildTasks(block *ethereum.Block, receipts []*ethereum.Receipt) ([]*Task, error) {
-	tasks := make([]*Task, len(block.Transactions))
+	var (
+		tasks  = make([]*Task, len(block.Transactions))
+		header = block.Header()
+	)
 
 	for index, transaction := range block.Transactions {
 		// There is no guarantee that the receipts provided by RPC will be in the same order as the transactions,
@@ -430,7 +433,7 @@ func (s *source) buildTasks(block *ethereum.Block, receipts []*ethereum.Receipt)
 		task := Task{
 			Network:     s.Network(),
 			ChainID:     uint64(chain),
-			Header:      block.Header(),
+			Header:      header,
 			Transaction: transaction,
 			Receipt:     receipt,
 		}


### PR DESCRIPTION
## Summary

Related to #202. In the previous implementation,  if we set the block batch size and number of block threads parameters of the Ethereum source to 8, and each block contained 200 transactions, there would be a total of 12,800 ( 8 * 8 * 200) transactions. In this case, the `buildTasks` function will repeatedly allocate a slice of length 200 a total of 12,800 times. This can cause significant memory allocation overhead.

- Before https://flamegraph.com/share/1755d160-fe03-11ee-8204-e6b38c1ccd74
- After https://flamegraph.com/share/0aba2f8c-fe03-11ee-a542-36adf59c1176

<img width="1840" alt="image" src="https://github.com/RSS3-Network/Node/assets/36319157/b0999c95-ec99-4bbc-8e48-4b48806ef0b5">

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [ ] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
