### PR TITLE
fix: rsshub auth logic

### DIFF
--- a/deploy/config.yaml
+++ b/deploy/config.yaml
@@ -49,10 +49,7 @@ component:
       endpoint: https://rsshub.app/
       parameters:
         authentication:
-          username:
-          password:
           access_key:
-          access_code:
 
   decentralized:
     # ethereum

--- a/internal/node/hub/rss/data.go
+++ b/internal/node/hub/rss/data.go
@@ -2,6 +2,9 @@ package rss
 
 import (
 	"context"
+	// nolint:gosec
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,17 +29,17 @@ func (h *Hub) getRSSHubData(ctx context.Context, path string, rawQuery string) (
 	request.Path = path
 	request.RawQuery = rawQuery
 
+	// fill in authentication config
+	if err := h.parseRSSHubAuthentication(ctx, request); err != nil {
+		return nil, fmt.Errorf("parse rsshub authentication: %w", err)
+	}
+
 	if !strings.Contains(request.RawQuery, RSSHubUMSPath) {
 		if request.RawQuery != "" {
 			request.RawQuery += "&" + RSSHubUMSPath
 		} else {
 			request.RawQuery = RSSHubUMSPath
 		}
-	}
-
-	// fill in authentication config
-	if err := h.parseRSSHubAuthentication(ctx, request); err != nil {
-		return nil, fmt.Errorf("parse rsshub authentication: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, request.String(), nil)
@@ -80,12 +83,13 @@ func (h *Hub) parseRSSHubAuthentication(_ context.Context, request *url.URL) err
 		return fmt.Errorf("parse parmeters: %w", err)
 	}
 
-	if option.Authentication.Username != "" && option.Authentication.Password != "" {
-		request.User = url.UserPassword(option.Authentication.Username, option.Authentication.Password)
-	}
+	if option.Authentication.AccessKey != "" {
+		// AccessKey calculation: md5(rawQuery + AccessKey)
+		// nolint:gosec
+		hash := md5.Sum([]byte("/" + request.Path + option.Authentication.AccessKey))
+		accessCode := hex.EncodeToString(hash[:])
 
-	if option.Authentication.AccessKey != "" && option.Authentication.AccessCode != "" {
-		request.RawQuery = fmt.Sprintf("%s&%s=%s", request.RawQuery, option.Authentication.AccessKey, option.Authentication.AccessCode)
+		request.RawQuery = fmt.Sprintf("%s?code=%s", request.RawQuery, accessCode)
 	}
 
 	return nil

--- a/internal/node/hub/rss/option.go
+++ b/internal/node/hub/rss/option.go
@@ -5,18 +5,19 @@ import (
 )
 
 type Option struct {
-	Authentication OptionAuthentication `yaml:"authentication"`
+	Authentication OptionAuthentication `json:"authentication" mapstructure:"authentication"`
 }
 
 type OptionAuthentication struct {
-	Username   string `yaml:"username"`
-	Password   string `yaml:"password"`
-	AccessKey  string `yaml:"access_key"`
-	AccessCode string `yaml:"access_code"`
+	AccessKey string `json:"access_key" mapstructure:"access_key"`
 }
 
 func NewOption(options *config.Parameters) (*Option, error) {
 	var instance Option
+
+	if options == nil {
+		return &instance, nil
+	}
 
 	if err := options.Decode(&instance); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

According to RSSHub doc: https://docs.rsshub.app/deploy/config#access-control-configurations

We will only allow users set access key in rss worker. And the node service will access the RSSHub instance only by code to avoid key leaking.

The code is generated using md5 `md5('/qdaily/column/59' + 'ILoveRSSHub')`

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No