### PR TITLE
fix(source/ethereum): remove invalid transaction fee field for arbitrum

### DIFF
--- a/internal/engine/source/ethereum/task.go
+++ b/internal/engine/source/ethereum/task.go
@@ -165,12 +165,7 @@ func (t Task) buildFeeArbitrumNitro() (*big.Int, error) {
 		types.LegacyTxType,
 		types.AccessListTxType,
 		types.DynamicFeeTxType:
-		fee, err := t.buildFeeDefault()
-		if err != nil {
-			return nil, err
-		}
-
-		return fee, nil
+		return t.buildFeeDefault()
 	case // The transaction fee is `effectiveGasPrice` * `gasUsed`.
 		ethereum.TransactionTypeArbitrumContract,
 		ethereum.TransactionTypeArbitrumUnsigned,

--- a/internal/engine/source/ethereum/task.go
+++ b/internal/engine/source/ethereum/task.go
@@ -170,7 +170,7 @@ func (t Task) buildFeeArbitrumNitro() (*big.Int, error) {
 			return nil, err
 		}
 
-		return new(big.Int).Add(fee, t.Receipt.L1Fee), nil
+		return fee, nil
 	case // The transaction fee is `effectiveGasPrice` * `gasUsed`.
 		ethereum.TransactionTypeArbitrumContract,
 		ethereum.TransactionTypeArbitrumUnsigned,


### PR DESCRIPTION
## Summary

Related #241. Incorrect use of Optimism's `l1Fee` field in Arbitrum.

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
