### PR TITLE
fix: change matters network from polygon to optimism

### DIFF
--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -44,11 +44,33 @@ observability:
       endpoint: localhost:4318
 
 endpoints:
+  farcaster:
+    url: https://nemes.farcaster.xyz:2281
   ethereum:
     url: https://rpc.ankr.com/eth
+  polygon:
+    url: https://rpc.ankr.com/polygon
+  avax:
+    url: https://rpc.ankr.com/avalanche
+  optimism:
+    url: https://rpc.ankr.com/optimism
+  arbitrum:
+    url: https://rpc.ankr.com/arbitrum
+  gnosis:
+    url: https://rpc.ankr.com/gnosis
+  linea:
+    url: https://rpc.linea.build
+  savm:
+    url: https://alpha-rpc-node-http.svmscan.io
+  binance-smart-chain:
+    url: https://rpc.ankr.com/bsc
   base:
     url: https://rpc.ankr.com/base
     http2_disabled: true
+  crossbell:
+    url: https://rpc.crossbell.io
+  vsl:
+    url: https://rpc.rss3.io
 
 component:
   rss:
@@ -68,63 +90,63 @@ component:
     - id: ethereum-rss3
       network: ethereum
       worker: rss3
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
         block_target:
     - id: polygon-lens
       network: polygon
       worker: lens
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       ipfs_gateways:
       parameters:
         block_start:
     - id: ethereum-opensea
       network: ethereum
       worker: opensea
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
     - id: ethereum-uniswap
       network: ethereum
       worker: uniswap
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
     - id: ethereum-optimism
       network: ethereum
       worker: optimism
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
     - id: polygon-aavegotchi
       network: polygon
       worker: aavegotchi
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       parameters:
           block_start: 48300005
     - id: ethereum-highlight
       network: ethereum
       worker: highlight
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
     - id: arbitrum-highlight
       network: arbitrum
       worker: highlight
-      endpoint: https://rpc.ankr.com/arbitrum
+      endpoint: arbitrum
       parameters:
         block_start:
     - id: polygon-highlight
       network: polygon
       worker: highlight
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       parameters:
           block_start:
     - id: optimism-highlight
       network: optimism
       worker: highlight
-      endpoint: https://rpc.ankr.com/optimism
+      endpoint: optimism
       parameters:
         block_start:
     - id: crossbell-crossbell
@@ -137,14 +159,13 @@ component:
     - id: farcaster-core
       network: farcaster
       worker: core
-      endpoint: https://nemes.farcaster.xyz:2281
+      endpoint: farcaster
       parameters:
         api_key:
     # arweave
     - id: arweave-mirror
       network: arweave
       worker: mirror
-      endpoint: https://arweave.net/
       ipfs_gateways:
       parameters:
         block_start:
@@ -152,7 +173,6 @@ component:
     - id: arweave-paragraph
       network: arweave
       worker: paragraph
-      endpoint: https://arweave.net/
       ipfs_gateways:
       parameters:
         block_start:
@@ -160,127 +180,127 @@ component:
     - id: ethereum-looksrare
       network: ethereum
       worker: looksrare
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
-    - id: polygon-matters
-      network: polygon
+    - id: optimism-matters
+      network: optimism
       worker: matters
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: optimism
       parameters:
         block_start:
     - id: arweave-momoka
       network: arweave
       worker: momoka
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       parameters:
         block_start:
         concurrent_block_requests:
     - id: ethereum-aave
       network: ethereum
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       worker: aave
       parameters:
         block_start:
     - id: polygon-aave
       network: polygon
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       worker: aave
       parameters:
         block_start:
     - id: avax-aave
       network: avax
-      endpoint: https://rpc.ankr.com/avalanche
+      endpoint: avax
       worker: aave
       parameters:
         block_start:
     - id: base-aave
       network: base
-      endpoint: https://rpc.ankr.com/base
+      endpoint: base
       worker: aave
       parameters:
         block_start:
     - id: optimism-aave
       network: optimism
-      endpoint: https://rpc.ankr.com/optimism
+      endpoint: optimism
       worker: aave
       parameters:
         block_start:
     - id: arbitrum-aave
       network: arbitrum
-      endpoint: https://rpc.ankr.com/arbitrum
+      endpoint: arbitrum
       worker: aave
       parameters:
         block_start:
     - id: polygon-iqwiki
       network: polygon
       worker: iqwiki
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       parameters:
         block_start:
     - id: ethereum-lido
       network: ethereum
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       worker: lido
       parameters:
         block_start:
     - id: ethereum-ens
       network: ethereum
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       worker: ens
       parameters:
         block_start:
     - id: ethereum-1inch
       network: ethereum
       worker: 1inch
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
     - id: vsl-core
       network: vsl
-      endpoint: https://rpc.rss3.io
+      endpoint: vsl
       worker: core
       parameters:
         block_start:
     - id: optimism-kiwistand
       network: optimism
-      endpoint: https://rpc.ankr.com/optimism
+      endpoint: optimism
       worker: kiwistand
       parameters:
         block_start:
     - id: savm-core
       network: savm
-      endpoint: https://alpha-rpc-node-http.svmscan.io
+      endpoint: savm
       worker: core
       parameters:
         block_start:
     - id: savm-uniswap
       network: savm
-      endpoint: https://alpha-rpc-node-http.svmscan.io
+      endpoint: savm
       worker: uniswap
       parameters:
         block_start:
     - id: savm-savm
       network: savm
-      endpoint: https://alpha-rpc-node-http.svmscan.io
+      endpoint: savm
       worker: savm
       parameters:
         block_start:
     - id: optimism-core
       network: optimism
-      endpoint: https://rpc.ankr.com/optimism
+      endpoint: optimism
       worker: core
       parameters:
         block_start:
     - id: polygon-core
       network: polygon
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       worker: core
       parameters:
         block_start:
     - id: arbitrum-core
       network: arbitrum
-      endpoint: https://rpc.ankr.com/arbitrum
+      endpoint: arbitrum
       worker: core
       parameters:
         block_start:
@@ -292,120 +312,120 @@ component:
         block_start:
     - id: binance-smart-chain-core
       network: binance-smart-chain
-      endpoint: https://rpc.ankr.com/bsc
+      endpoint: binance-smart-chain
       worker: core
       parameters:
         block_start: 34436412
         concurrent_block_requests: 1
     - id: gnosis-core
       network: gnosis
-      endpoint: https://rpc.ankr.com/gnosis
+      endpoint: gnosis
       worker: core
       parameters:
         block_start:
     - id: linea-core
       network: linea
-      endpoint: https://rpc.linea.build
+      endpoint: linea
       worker: core
       parameters:
           block_start:
     - id: linea-uniswap
       network: linea
-      endpoint: https://rpc.linea.build
+      endpoint: linea
       worker: uniswap
       parameters:
         block_start:
     - id: vsl-rss3
       network: vsl
-      endpoint: https://rpc.rss3.io
+      endpoint: vsl
       worker: rss3
     - id: ethereum-vsl
       network: ethereum
       worker: vsl
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
     - id: ethereum-stargate
       network: ethereum
       worker: stargate
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
     - id: arbitrum-stargate
       network: arbitrum
       worker: stargate
-      endpoint: https://rpc.ankr.com/arbitrum
+      endpoint: arbitrum
       parameters:
         block_start:
     - id: linea-stargate
       network: linea
-      endpoint: https://rpc.linea.build
+      endpoint: linea
       worker: stargate
       parameters:
         block_start:
     - id: binance-smart-chain-stargate
       network: binance-smart-chain
-      endpoint: https://rpc.ankr.com/bsc
+      endpoint: binance-smart-chain
       worker: stargate
       parameters:
         block_start:
     - id: base-stargate
       network: base
-      endpoint: https://developer-access-mainnet.base.orgss
+      endpoint: base
       worker: stargate
       parameters:
         block_start:
     - id: optimism-stargate
       network: optimism
-      endpoint: https://rpc.ankr.com/optimism
+      endpoint: optimism
       worker: stargate
       parameters:
         block_start:
     - id: polygon-stargate
       network: polygon
       worker: stargate
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       parameters:
         block_start:
     - id: avax-stargate
       network: avax
-      endpoint: https://rpc.ankr.com/avalanche
+      endpoint: avax
       worker: stargate
       parameters:
         block_start:
     - id: ethereum-curve
       network: ethereum
       worker: curve
-      endpoint: https://rpc.ankr.com/eth
+      endpoint: ethereum
       parameters:
         block_start:
     - id: arbitrum-curve
       network: arbitrum
       worker: curve
-      endpoint: https://rpc.ankr.com/arbitrum
+      endpoint: arbitrum
       parameters:
         block_start:
     - id: avax-curve
       network: avax
-      endpoint: https://rpc.ankr.com/avalanche
+      endpoint: avax
       worker: curve
       parameters:
         block_start:
     - id: gnosis-curve
       network: gnosis
-      endpoint: https://rpc.ankr.com/gnosis
+      endpoint: gnosis
       worker: curve
       parameters:
         block_start:
     - id: optimism-curve
       network: optimism
       worker: curve
-      endpoint: https://rpc.ankr.com/optimism
+      endpoint: optimism
       parameters:
         block_start:
     - id: polygon-curve
       network: polygon
       worker: curve
-      endpoint: https://rpc.ankr.com/polygon
+      endpoint: polygon
       parameters:
         block_start:

--- a/internal/engine/worker/contract/matters/worker.go
+++ b/internal/engine/worker/contract/matters/worker.go
@@ -55,7 +55,7 @@ func (w *worker) Platform() string {
 
 func (w *worker) Network() []network.Network {
 	return []network.Network{
-		network.Polygon,
+		network.Optimism,
 	}
 }
 

--- a/internal/engine/worker/contract/matters/worker_test.go
+++ b/internal/engine/worker/contract/matters/worker_test.go
@@ -2,12 +2,25 @@ package matters_test
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/rss3-network/node/config"
 	source "github.com/rss3-network/node/internal/engine/source/ethereum"
 	worker "github.com/rss3-network/node/internal/engine/worker/contract/matters"
+	"github.com/rss3-network/node/provider/ethereum"
+	"github.com/rss3-network/node/provider/ethereum/contract/matters"
+	"github.com/rss3-network/node/provider/ethereum/endpoint"
+	workerx "github.com/rss3-network/node/schema/worker"
 	activityx "github.com/rss3-network/protocol-go/schema/activity"
+	"github.com/rss3-network/protocol-go/schema/metadata"
+	"github.com/rss3-network/protocol-go/schema/network"
+	"github.com/rss3-network/protocol-go/schema/tag"
+	"github.com/rss3-network/protocol-go/schema/typex"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,153 +38,144 @@ func TestWorker_Matters(t *testing.T) {
 		want      *activityx.Activity
 		wantError require.ErrorAssertionFunc
 	}{
-		// {
-		//	name: "Curation",
-		//	arguments: arguments{
-		//		task: &source.Task{
-		//			Network: network.Polygon,
-		//			ChainID: 137,
-		//			Header: &ethereum.Header{
-		//				Hash:         common.HexToHash("0xd287e85c28567ff5e0ecde319f9e9d3cd39c399c3cd97015af10adfc0b971427"),
-		//				ParentHash:   common.HexToHash("0x623c004b7150f523123181934c5d7d71afa229f7f98bad19448348eab0fbce24"),
-		//				UncleHash:    common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
-		//				Coinbase:     common.HexToAddress("0xbDBd4347b082D9d6BdF2Da4555a37Ce52a2e2120"),
-		//				Number:       lo.Must(new(big.Int).SetString("46169613", 0)),
-		//				GasLimit:     30000000,
-		//				GasUsed:      8071254,
-		//				Timestamp:    1691743370,
-		//				BaseFee:      lo.Must(new(big.Int).SetString("46050144999", 0)),
-		//				Transactions: nil,
-		//			},
-		//			Transaction: &ethereum.Transaction{
-		//				BlockHash: common.HexToHash("0x406420c77151dd2779f647967aaee7b2ae25248bbb51b53de4d8912c904dbd34"),
-		//				From:      common.HexToAddress("0x18Fb694EbAE03a78f038F54362592Dd89c0e300C"),
-		//				Gas:       118339,
-		//				GasPrice:  lo.Must(new(big.Int).SetString("76050144999", 10)),
-		//				Hash:      common.HexToHash("0x406420c77151dd2779f647967aaee7b2ae25248bbb51b53de4d8912c904dbd34"),
-		//				Input:     hexutil.MustDecode("0xdbcdaf5b000000000000000000000000099d854cd6f996cd1cb1ffc1df0e197a774426e2000000000000000000000000c2132d05d31c914a87c6611c10748aeb04b58e8f00000000000000000000000000000000000000000000000000000000000a875000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000035697066733a2f2f516d52546e4a4e316b77746b766b576d326669635455433771486244714e316361483763574b79397158595336310000000000000000000000"),
-		//				To:        lo.ToPtr(common.HexToAddress("0x5edebbdae7B5C79a69AaCF7873796bb1Ec664DB8")),
-		//				Value:     lo.Must(new(big.Int).SetString("0", 0)),
-		//				Type:      2,
-		//				ChainID:   lo.Must(new(big.Int).SetString("137", 0)),
-		//			},
-		//			Receipt: &ethereum.Receipt{
-		//				BlockHash:         common.HexToHash("0xd287e85c28567ff5e0ecde319f9e9d3cd39c399c3cd97015af10adfc0b971427"),
-		//				BlockNumber:       lo.Must(new(big.Int).SetString("46169613", 0)),
-		//				ContractAddress:   nil,
-		//				CumulativeGasUsed: 7216947,
-		//				EffectiveGasPrice: hexutil.MustDecodeBig("0x11b4f11ee7"),
-		//				GasUsed:           74710,
-		//				Logs: []*ethereum.Log{{
-		//					Address: common.HexToAddress("0xc2132D05D31c914a87C6611C10748AEb04B58e8F"),
-		//					Topics: []common.Hash{
-		//						common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
-		//						common.HexToHash("0x00000000000000000000000018fb694ebae03a78f038f54362592dd89c0e300c"),
-		//						common.HexToHash("0x000000000000000000000000099d854cd6f996cd1cb1ffc1df0e197a774426e2"),
-		//					},
-		//					Data:            hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000a8750"),
-		//					BlockNumber:     lo.Must(new(big.Int).SetString("46169613", 0)),
-		//					TransactionHash: common.HexToHash("0x406420c77151dd2779f647967aaee7b2ae25248bbb51b53de4d8912c904dbd34"),
-		//					Index:           203,
-		//					Removed:         false,
-		//				}, {
-		//					Address: common.HexToAddress("0xc2132D05D31c914a87C6611C10748AEb04B58e8F"),
-		//					Topics: []common.Hash{
-		//						common.HexToHash("0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"),
-		//						common.HexToHash("0x00000000000000000000000018fb694ebae03a78f038f54362592dd89c0e300c"),
-		//						common.HexToHash("0x0000000000000000000000005edebbdae7b5c79a69aacf7873796bb1ec664db8"),
-		//					},
-		//					Data:            hexutil.MustDecode("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffe1ee296"),
-		//					BlockNumber:     lo.Must(new(big.Int).SetString("46169613", 0)),
-		//					TransactionHash: common.HexToHash("0x406420c77151dd2779f647967aaee7b2ae25248bbb51b53de4d8912c904dbd34"),
-		//					Index:           204,
-		//					Removed:         false,
-		//				}, {
-		//					Address: common.HexToAddress("0x5edebbdae7B5C79a69AaCF7873796bb1Ec664DB8"),
-		//					Topics: []common.Hash{
-		//						common.HexToHash("0xc2e41b3d49bbccbac6ceb142bad6119608adf4f1ee1ca5cc6fc332e0ca2fc602"),
-		//						common.HexToHash("0x00000000000000000000000018fb694ebae03a78f038f54362592dd89c0e300c"),
-		//						common.HexToHash("0x000000000000000000000000099d854cd6f996cd1cb1ffc1df0e197a774426e2"),
-		//						common.HexToHash("0x000000000000000000000000c2132d05d31c914a87c6611c10748aeb04b58e8f"),
-		//					},
-		//					Data:            hexutil.MustDecode("0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000a87500000000000000000000000000000000000000000000000000000000000000035697066733a2f2f516d52546e4a4e316b77746b766b576d326669635455433771486244714e316361483763574b79397158595336310000000000000000000000"),
-		//					BlockNumber:     lo.Must(new(big.Int).SetString("46169613", 0)),
-		//					TransactionHash: common.HexToHash("0x406420c77151dd2779f647967aaee7b2ae25248bbb51b53de4d8912c904dbd34"),
-		//					Index:           205,
-		//					Removed:         false,
-		//				}, {
-		//					Address: common.HexToAddress("0x0000000000000000000000000000000000001010"),
-		//					Topics: []common.Hash{
-		//						common.HexToHash("0x4dfe1bbbcf077ddc3e01291eea2d5c70c2b422b415d95645b9adcfd678cb1d63"),
-		//						common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000001010"),
-		//						common.HexToHash("0x00000000000000000000000018fb694ebae03a78f038f54362592dd89c0e300c"),
-		//						common.HexToHash("0x000000000000000000000000bdbd4347b082d9d6bdf2da4555a37ce52a2e2120"),
-		//					},
-		//					Data:            hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000007f6735255c8000000000000000000000000000000000000000000000000009ac8d1aa4def2b4200000000000000000000000000000000000000000000306673636b994b170d050000000000000000000000000000000000000000000000009ac0db36fb996342000000000000000000000000000000000000000000003066736b620c9d6cd505"),
-		//					BlockNumber:     lo.Must(new(big.Int).SetString("46169613", 0)),
-		//					TransactionHash: common.HexToHash("0x406420c77151dd2779f647967aaee7b2ae25248bbb51b53de4d8912c904dbd34"),
-		//					Index:           206,
-		//					Removed:         false,
-		//				}},
-		//				Status:           1,
-		//				TransactionHash:  common.HexToHash("0x406420c77151dd2779f647967aaee7b2ae25248bbb51b53de4d8912c904dbd34"),
-		//				TransactionIndex: 41,
-		//			},
-		//		},
-		//		config: &config.Module{
-		//			Network:  network.Polygon,
-		//			Endpoint: config.Endpoint{
-		//			URL: endpoint.MustGet(network.Polygon),
-		//			},
-		//		},
-		//	},
-		//	want: &activityx.Activity{
-		//		ID:      "0x406420c77151dd2779f647967aaee7b2ae25248bbb51b53de4d8912c904dbd34",
-		//		Network: network.Polygon,
-		//		Index:   41,
-		//		From:    "0x18Fb694EbAE03a78f038F54362592Dd89c0e300C",
-		//		To:      matters.AddressCuration.String(),
-		//		Type:    typex.SocialReward,
-		//		Calldata: &activityx.Calldata{
-		//			FunctionHash: "0xdbcdaf5b",
-		//		},
-		//		Tag:      tag.Social,
-		//		Platform: workerx.PlatformMatters.String(),
-		//		Fee: &activityx.Fee{
-		//			Amount:  lo.Must(decimal.NewFromString("5681706332875290")),
-		//			Decimal: 18,
-		//		},
-		//		TotalActions: 1,
-		//		Actions: []*activityx.Action{
-		//			{
-		//				Type:     typex.SocialReward,
-		//				Tag:      tag.Social,
-		//				Platform: workerx.PlatformMatters.String(),
-		//				From:     "0x18Fb694EbAE03a78f038F54362592Dd89c0e300C",
-		//				To:       "0x099d854cD6F996cD1CB1ffc1Df0E197A774426e2",
-		//				Metadata: &metadata.SocialPost{
-		//					Reward: &metadata.Token{
-		//						Address:  lo.ToPtr(common.HexToAddress("0xc2132D05D31c914a87C6611C10748AEb04B58e8F").String()),
-		//						Value:    lo.ToPtr(decimal.NewFromBigInt(big.NewInt(690000), 0)),
-		//						Name:     "(PoS) Tether USD",
-		//						Symbol:   "USDT",
-		//						Standard: metadata.StandardERC20,
-		//						Decimals: 6,
-		//					},
-		//					Target: &metadata.SocialPost{
-		//						Handle:  "chorsee",
-		//						Title:   "與他瑪同哭 —— 終止暴力對待婦女音樂會的共振 - 楚思 (chorsee)",
-		//						Summary: "近日在台灣揭發的連串Me too事件，還有印度女摔跤手奮力就性侵事件示威。在臉書上見到非常多關於台灣事件的評論和分析，獲益良多，也望塵莫及，自己未有新的觀點和見解可分享，謹以一篇舊文章為發聲的女性聊表聲援支持，也希望當中分享的歌曲能帶來一些安慰。（抱）",
-		//						Body:    "【註：2018年寫的舊文章，於香港基督教媒體《時代論壇》刊登，今次刊登時作了少許修改。】\n\n性侵犯受害人在網上勇敢自白，隨之而來一群判官，嘲諷攻擊。我最看不過眼的不是當中分析，是目中無人的態度，「佢擺明就係攞光環」（他一定是為了搏取光環）這些話明擺著是討厭，但故作持平大剌剌地指點如何是更好的做法，都可能是一種冷漠的傷害。\n\n參加過就同性戀作信仰反省的講座，立場兩極的講員搬出不同理論，腔調平穩，辯論時彬彬有禮，但聽來很遙遠。我提問：「如果有個同性戀者就在這裡，你會跟他說什麼？」講員沒有直接回應，後補的一番分析依舊稱呼「同性戀者」、「他們」。\n\n當受害者在我們跟前，我們懂得怎樣直接向「您」說話嗎？\n\n有天收到電話，朋友跟我凌亂地說了些酒吧、陌生人、醒來等字眼，繞過關鍵而太痛苦的一詞，問該怎辦。她還在強裝鎮定，我更覺一片空白，失語。\n\n* * *\n\n早前參與「他瑪的呼聲——終止暴力對待婦女音樂會」，由基督教協進會的性別公義事工籌辦。音樂會名字的「他瑪」所指的是聖經的撒母耳記下所記，大衛的女兒，她被同父異母兄長性侵犯。\n\n參與音樂會時沒特別期待，怎料好像將內心赤裸裸地送進了SPA，是一場意想不到的觸動震撼，無法旁觀， 只能認真地感受內心一切起伏。\n\n第一首歌就是反覆的一聲聲「容許我淒泣」，開闢一個讓情緒自由流動的空間，托住了讀經的姊妹以及在座每人，我們看到姊妹讀畢他瑪故事的淚水，我們也絕對容許淒泣。之後，我們聽到更多其他的「他瑪」的故事，甚至有姊妹勇敢講親身遭遇，不是罐頭式「我改變了」的樂觀，但也不是糾纏於痛苦的細節，是切實的掙扎，也是向上帝切切的祈求。\n\n找不到中文歌詞版，推介我喜歡的Celtic Woman 版，歌詞就是《容許我淒泣》的意思\n\n向受害者說話不容易，何況跟他們同哭——不只是為他們而哭，而是不得不發現自己內心同樣脆弱，胸腔同樣流轉一股沸騰酸苦。不只是聽眾，籌備音樂會的人，也進入這段旅程，內心驟然要敞開，舒坦前必先疼痛，像拉開久未伸展的筋骨。\n\n敞開的赤裸是如此危險，只能求上主以愛填補，這時同讀「婦女信經」，「我信聖靈，上主的陰性之靈，她就像母雞，創造孕育我們，以她的翅膀覆庇我們。」還齊誦「醫治連禱」：「求你的醫治大能，觸摸一切混亂、自我懷疑的身心，並光照他們。」份外體會到，我們真的需要向上主呼求。\n\n最終尋求的希望，是《For everyone born》，作詞的Shirley Erena Murray將「世界人權宣言」放置於福音的處境，”God will delight when we are creators of justice and joy, compassion and peace.” 關懷不只限於某性別，是由此出發，去為祈願一個更公義平等的世界而歌。\n\n性別公義事工有辦工作坊作教育，也有安排專業輔導和牧師等人設立性侵受害人支援小組，還辦這音樂會，滋養安慰、省察、呼求，塑造著各人的內心，難能可貴。議題的事理固然要釐清，但其情感面向，更不能忽視的是活生生的人的故事、呼求、脆弱，願我們能同哀哭，才有可能同喜樂。\n\n音樂會的精華片段\n\n願公義得以伸張。願每一個受害人得到更多安慰、滋潤，大大力給你們一個擁抱，辛苦了。\n\n* * *\n\nP.S. 我將當天音樂會的歌曲串成了一個 [歌單](https://www.youtube.com/playlist?list=PL25ePuQiYMITe9DmoKdSKfx8ryToHHDCN) 作分享。脫離了整個音樂會的鋪排後，未必能傳遞到歌曲在音樂會中的含義，可是或能分享到一些安慰和激勵，特別也推介《Rise Up》和《Nobody knows the trouble I've seen》這兩首歌。",
-		//					},
-		//				},
-		//			},
-		//		},
-		//		Status:    true,
-		//		Timestamp: 1691743370,
-		//	},
-		//	wantError: require.NoError,
-		// },
+		{
+			name: "Curation",
+			arguments: arguments{
+				task: &source.Task{
+					Network: network.Optimism,
+					ChainID: 10,
+					Header: &ethereum.Header{
+						Hash:         common.HexToHash("0x7ba6c85ff9d6eba5cb5f0fb6974ff4efbdef4dc4f093a2a00f50a851c8a49bcf"),
+						ParentHash:   common.HexToHash("0x347a738508aec78e101d6790b564201959b7841473dd6f4e556d13443161cbd2"),
+						UncleHash:    common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
+						Coinbase:     common.HexToAddress("0x4200000000000000000000000000000000000011"),
+						Number:       lo.Must(new(big.Int).SetString("117061980", 0)),
+						GasLimit:     30000000,
+						GasUsed:      23316448,
+						Timestamp:    1709722737,
+						BaseFee:      lo.Must(new(big.Int).SetString("227967", 0)),
+						Transactions: nil,
+					},
+					Transaction: &ethereum.Transaction{
+						BlockHash: common.HexToHash("0x3000bbbfe0fd1d7f13eb8ff9e324db0c9ae75466e6666881216377f8d6fce2a0"),
+						From:      common.HexToAddress("0x869871ba7eC8BCB59530a04e1e28A42A208a697b"),
+						Gas:       70081,
+						GasPrice:  lo.Must(new(big.Int).SetString("1011502", 10)),
+						Hash:      common.HexToHash("0x3000bbbfe0fd1d7f13eb8ff9e324db0c9ae75466e6666881216377f8d6fce2a0"),
+						Input:     hexutil.MustDecode("0xdbcdaf5b00000000000000000000000073d5f95b8f6fc4178aa934c44d7acc7dc2a6daf800000000000000000000000094b008aa00579c1307b0ef2c499ad98a8ce58e5800000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000035697066733a2f2f516d58325245656f724b786d347170667479467a514850683243654a654143364368796e51537a62506a675866470000000000000000000000"),
+						To:        lo.ToPtr(common.HexToAddress("0x5edebbdae7B5C79a69AaCF7873796bb1Ec664DB8")),
+						Value:     lo.Must(new(big.Int).SetString("0", 0)),
+						Type:      2,
+						ChainID:   lo.Must(new(big.Int).SetString("10", 0)),
+					},
+					Receipt: &ethereum.Receipt{
+						BlockHash:         common.HexToHash("0x7ba6c85ff9d6eba5cb5f0fb6974ff4efbdef4dc4f093a2a00f50a851c8a49bcf"),
+						BlockNumber:       lo.Must(new(big.Int).SetString("117061980", 0)),
+						ContractAddress:   nil,
+						CumulativeGasUsed: 22764157,
+						EffectiveGasPrice: hexutil.MustDecodeBig("0xf6f2e"),
+						GasUsed:           69223,
+						L1GasPrice:        lo.Must(new(big.Int).SetString("67629803535", 0)),
+						L1GasUsed:         lo.Must(new(big.Int).SetString("4072", 0)),
+						L1Fee:             lo.Must(new(big.Int).SetString("188365775036251", 0)),
+						FeeScalar:         lo.Must(new(big.Float).SetString("0.684")),
+						Logs: []*ethereum.Log{{
+							Address: common.HexToAddress("0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"),
+							Topics: []common.Hash{
+								common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+								common.HexToHash("0x000000000000000000000000869871ba7ec8bcb59530a04e1e28a42a208a697b"),
+								common.HexToHash("0x00000000000000000000000073d5f95b8f6fc4178aa934c44d7acc7dc2a6daf8"),
+							},
+							Data:            hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000000f4240"),
+							BlockNumber:     lo.Must(new(big.Int).SetString("117061980", 0)),
+							TransactionHash: common.HexToHash("0x3000bbbfe0fd1d7f13eb8ff9e324db0c9ae75466e6666881216377f8d6fce2a0"),
+							Index:           147,
+							Removed:         false,
+						}, {
+							Address: common.HexToAddress("0x94b008aA00579c1307B0EF2c499aD98a8ce58e58"),
+							Topics: []common.Hash{
+								common.HexToHash("0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"),
+								common.HexToHash("0x000000000000000000000000869871ba7ec8bcb59530a04e1e28a42a208a697b"),
+								common.HexToHash("0x0000000000000000000000005edebbdae7b5c79a69aacf7873796bb1ec664db8"),
+							},
+							Data:            hexutil.MustDecode("0x00000000000000000000000000000000000000000000000000000000006acfc0"),
+							BlockNumber:     lo.Must(new(big.Int).SetString("117061980", 0)),
+							TransactionHash: common.HexToHash("0x3000bbbfe0fd1d7f13eb8ff9e324db0c9ae75466e6666881216377f8d6fce2a0"),
+							Index:           148,
+							Removed:         false,
+						}, {
+							Address: common.HexToAddress("0x5edebbdae7B5C79a69AaCF7873796bb1Ec664DB8"),
+							Topics: []common.Hash{
+								common.HexToHash("0xc2e41b3d49bbccbac6ceb142bad6119608adf4f1ee1ca5cc6fc332e0ca2fc602"),
+								common.HexToHash("0x000000000000000000000000869871ba7ec8bcb59530a04e1e28a42a208a697b"),
+								common.HexToHash("0x00000000000000000000000073d5f95b8f6fc4178aa934c44d7acc7dc2a6daf8"),
+								common.HexToHash("0x00000000000000000000000094b008aa00579c1307b0ef2c499ad98a8ce58e58"),
+							},
+							Data:            hexutil.MustDecode("0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000035697066733a2f2f516d58325245656f724b786d347170667479467a514850683243654a654143364368796e51537a62506a675866470000000000000000000000"),
+							BlockNumber:     lo.Must(new(big.Int).SetString("117061980", 0)),
+							TransactionHash: common.HexToHash("0x3000bbbfe0fd1d7f13eb8ff9e324db0c9ae75466e6666881216377f8d6fce2a0"),
+							Index:           149,
+							Removed:         false,
+						}},
+						Status:           1,
+						TransactionHash:  common.HexToHash("0x3000bbbfe0fd1d7f13eb8ff9e324db0c9ae75466e6666881216377f8d6fce2a0"),
+						TransactionIndex: 8,
+					},
+				},
+				config: &config.Module{
+					Network: network.Optimism,
+					Endpoint: config.Endpoint{
+						URL: endpoint.MustGet(network.Optimism),
+					},
+				},
+			},
+			want: &activityx.Activity{
+				ID:      "0x3000bbbfe0fd1d7f13eb8ff9e324db0c9ae75466e6666881216377f8d6fce2a0",
+				Network: network.Optimism,
+				Index:   8,
+				From:    "0x869871ba7eC8BCB59530a04e1e28A42A208a697b",
+				To:      matters.AddressCuration.String(),
+				Type:    typex.SocialReward,
+				Calldata: &activityx.Calldata{
+					FunctionHash: "0xdbcdaf5b",
+				},
+				Tag:      tag.Social,
+				Platform: workerx.PlatformMatters.String(),
+				Fee: &activityx.Fee{
+					Amount:  lo.Must(decimal.NewFromString("188435794239197")),
+					Decimal: 18,
+				},
+				TotalActions: 1,
+				Actions: []*activityx.Action{
+					{
+						Type:     typex.SocialReward,
+						Tag:      tag.Social,
+						Platform: workerx.PlatformMatters.String(),
+						From:     "0x869871ba7eC8BCB59530a04e1e28A42A208a697b",
+						To:       "0x73d5f95B8f6FC4178aA934c44D7Acc7dC2a6DAf8",
+						Metadata: &metadata.SocialPost{
+							Reward: &metadata.Token{
+								Address:  lo.ToPtr(common.HexToAddress("0x94b008aA00579c1307B0EF2c499aD98a8ce58e58").String()),
+								Value:    lo.ToPtr(decimal.NewFromBigInt(big.NewInt(1000000), 0)),
+								Name:     "Tether USD",
+								Symbol:   "USDT",
+								Standard: metadata.StandardERC20,
+								Decimals: 6,
+							},
+							Target: &metadata.SocialPost{
+								Handle:  "guo",
+								Title:   "ZuSocial: notes and reflections - 刘果 | Guo Liu (guo)",
+								Summary: "In November Istanbul, alongside the vibrant communities of ZuConnect and Devconnect, we held a 2-week hacker house focusing on decentralized social.",
+								Body:    "![](./06e20887-c9da-4efd-b02f-47367cc5277f.png)Sunset in Istanbul, by Eunhye\n\nZuSocial was more than just an event; it was a chance to connect with a diverse group of individuals, who share the belief of decentralization and participate in an emerging vision of a better social network.\n\nIn the areas where blockchain technology could fundamentally change, social network might just rival its impact on finance, if not surpass it. More and more people get their information from some kind of social network, while at the same time, the flaws in our centralized social media platforms are becoming more apparent.\n\nThese platforms often prioritize seeking attention over fostering genuine human connections. They centralize control over the flow of information, becoming tools of manipulation and even weapons during conflicts. Our thoughts, shared in these virtual public spaces, are gradually privatized without us even realizing it.\n\nDecentralization offers the potential to address these issues. It can potentially make censorship and propaganda more difficult, replacing the dominance of a few platforms with a landscape of fairer protocols and more efficient markets.\n\nHowever, we know very little about how to build these decentralized alternatives. The world of blockchain and related technologies looks vastly different from our current social media landscape, and might not be directly meaningful to an end user. We also lack a deep understanding of how to construct digital public spaces since they are a relatively new concept.\n\nTo navigate this uncharted territory, we must seek guidance from fields that have amassed more experience. At ZuSocial, we intentionally drew inspiration from the physical world and borrowed tools from disciplines like architecture and urban planning. It's a fascinating journey, especially during events like ZuConnect, ZuSocial, and DevConnect, where we can experiment and learn by observing our own interactions.\n\nBelow are some of my learnings and reflections during ZuSocial. The most profound conversations were often free-flowing and unstructured, but I've organized my thoughts into four distinct threads.\n\n- [ZuConnect decentralized social day: lessons from the past](https://liuguo.eth.limo/505333-zu-connect-decentralized-day-lessons-from-the-past/)\n\n- [What does blockchain bring to social protocol?](https://liuguo.eth.limo/505337-what-does-blockchain-bring-to-social-protocol/)\n\n- [The economics of Matters Town](https://liuguo.eth.limo/505387-the-economics-of-matters-town/)\n\n- [Groups and autonomous spaces: a mental model for better social networks](https://liuguo.eth.limo/505396-groups-and-autonomous-spaces-a-mental-model-for-better-social-networks/)",
+							},
+						},
+					},
+				},
+				Status:    true,
+				Timestamp: 1709722737,
+			},
+			wantError: require.NoError,
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -191,7 +195,9 @@ func TestWorker_Matters(t *testing.T) {
 
 			activity, err := instance.Transform(ctx, testcase.arguments.task)
 			testcase.wantError(t, err)
+
 			// t.Log(string(lo.Must(json.MarshalIndent(activity, "", "\x20\x20"))))
+
 			require.Equal(t, testcase.want, activity)
 
 			t.Log(activity)

--- a/internal/node/component/network/relation.go
+++ b/internal/node/component/network/relation.go
@@ -210,7 +210,6 @@ var NetworkToWorkersMap = map[network.Network][]worker.Worker{
 		worker.Highlight,
 		worker.IQWiki,
 		worker.Lens,
-		worker.Matters,
 		worker.Stargate,
 	},
 	network.Crossbell: {
@@ -232,6 +231,7 @@ var NetworkToWorkersMap = map[network.Network][]worker.Worker{
 		worker.Curve,
 		worker.Highlight,
 		worker.KiwiStand,
+		worker.Matters,
 		worker.Stargate,
 	},
 	network.Arbitrum: {

--- a/tool/testcase/template/ethereum.tmpl
+++ b/tool/testcase/template/ethereum.tmpl
@@ -1,6 +1,6 @@
 {{ define "ethereum" }}
 {
-    Network: filter.NetworkEthereum,
+    Network: network.Ethereum,
     ChainID: {{ .ChainID }},
     Header: &ethereum.Header{
         Hash: common.HexToHash("{{ .Header.Hash}}"),


### PR DESCRIPTION
## Summary

matters was on polygon network before block [53561096](https://polygonscan.com/block/53561096), the last tx is: [0x5edebbdae7b5c79a69aacf7873796bb1ec664db8](https://polygonscan.com/address/0x5edebbdae7b5c79a69aacf7873796bb1ec664db8)

now it's on Optimisim blockchain, the contract was deployed on block [117058632](https://optimistic.etherscan.io/block/117058632), the deployment tx is [0xfc7a79202bcb1b3060e3f4b409505009b9539e0e561d4bdb19743d1757b9efdb](https://optimistic.etherscan.io/tx/0xfc7a79202bcb1b3060e3f4b409505009b9539e0e561d4bdb19743d1757b9efdb)

this pr changes the network of matters worker, update test cases.

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No