### PR TITLE
fix: add global arweave endpoint

### DIFF
--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -71,6 +71,8 @@ endpoints:
     url: https://rpc.crossbell.io
   vsl:
     url: https://rpc.rss3.io
+  arweave:
+    url: https://arweave.net
 
 component:
   rss:
@@ -165,6 +167,7 @@ component:
     # arweave
     - id: arweave-mirror
       network: arweave
+      endpoint: arweave
       worker: mirror
       ipfs_gateways:
       parameters:
@@ -172,6 +175,7 @@ component:
         concurrent_block_requests:
     - id: arweave-paragraph
       network: arweave
+      endpoint: arweave
       worker: paragraph
       ipfs_gateways:
       parameters:


### PR DESCRIPTION
## Summary

add global arweave endpoint in example config

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No