### PR TITLE
chore: adjust arbitrum and crossbell network tolerance

### DIFF
--- a/config/parameter/network.go
+++ b/config/parameter/network.go
@@ -10,12 +10,12 @@ import (
 const NumberOfMonthsToCover = 3
 
 var NetworkTolerance = map[network.Network]uint64{
-	network.Arbitrum:          100,
+	network.Arbitrum:          1000,
 	network.Arweave:           100,
 	network.Avalanche:         100,
 	network.Base:              100,
 	network.BinanceSmartChain: 100,
-	network.Crossbell:         100,
+	network.Crossbell:         500,
 	network.Ethereum:          100,
 	network.Farcaster:         3600000,
 	network.Gnosis:            100,


### PR DESCRIPTION
## Summary

We use network tolerance to monitor worker status. A threshold of 100 blocks is too strict for the Arbitrum and Crossbell blockchains, causing frequent changes from `ready` to `indexing` status.

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [ ] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No