### PR TITLE
feat: use redis endpoint string instead of array

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -154,7 +154,7 @@ type OpenTelemetryTracesConfig struct {
 }
 
 type Redis struct {
-	Endpoints    []string `mapstructure:"endpoints" default:"['localhost:6379']" validate:"required"`
+	Endpoint     string   `mapstructure:"endpoint" default:"localhost:6379" validate:"required"`
 	Username     string   `mapstructure:"username"`
 	Password     string   `mapstructure:"password"`
 	DisableCache bool     `mapstructure:"disable_cache" default:"true"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,8 +42,7 @@ stream:
   topic: rss3.node.activities
   uri: localhost:9092
 redis:
-  endpoints:
-    - localhost:6379
+  endpoint: localhost:6379
   username:
   password:
   disable_cache: true
@@ -112,9 +111,7 @@ component:
     "uri": "localhost:9092"
   },
   "redis": {
-    "endpoints": [
-      "localhost:6379"
-    ],
+    "endpoint": "localhost:6379",
     "username": "",
     "password": "",
     "disable_cache": true
@@ -197,7 +194,7 @@ topic = "rss3.node.activities"
 uri = "localhost:9092"
 
 [redis]
-endpoints = ["localhost:6379"]
+endpoint = "localhost:6379"
 username = ""
 password = ""
 disable_cache = true
@@ -325,7 +322,7 @@ var configFileExcept = &File{
 		URI:    "localhost:9092",
 	},
 	Redis: &Redis{
-		Endpoints:    []string{"localhost:6379"},
+		Endpoint:     "localhost:6379",
 		Username:     "",
 		Password:     "",
 		DisableCache: true,

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -21,8 +21,7 @@ stream:
   uri: localhost:9092
 
 redis:
-  endpoints:
-    - localhost:6379
+  endpoint: localhost:6379
   username:
   password:
   disable_cache: true

--- a/deploy/example/config.min.yaml
+++ b/deploy/example/config.min.yaml
@@ -31,8 +31,7 @@ observability:
       endpoint: localhost:4318
 
 redis:
-  endpoints:
-    - redis:6379
+  endpoint: localhost:6379
   username:
   password:
   disable_cache: true

--- a/internal/engine/worker/contract/curve/worker_test.go
+++ b/internal/engine/worker/contract/curve/worker_test.go
@@ -1022,9 +1022,7 @@ func TestWorker_Ethereum(t *testing.T) {
 
 	// Connect to Redis
 	redisClient, err := redisx.NewClient(config.Redis{
-		Endpoints: []string{
-			container.DefaultAddress(),
-		},
+		Endpoint: container.DefaultAddress(),
 	})
 	require.NoError(t, err)
 

--- a/internal/engine/worker/core/ethereum/worker_test.go
+++ b/internal/engine/worker/core/ethereum/worker_test.go
@@ -49,9 +49,7 @@ func setup(t *testing.T) {
 
 		// Connect to Redis without TLS
 		redisClient, err = redisx.NewClient(config.Redis{
-			Endpoints: []string{
-				container.DefaultAddress(),
-			},
+			Endpoint: container.DefaultAddress(),
 			TLS: config.RedisTLS{
 				Enabled:            false,
 				CAFile:             "/path/to/ca.crt",

--- a/internal/node/monitor/monitor_test.go
+++ b/internal/node/monitor/monitor_test.go
@@ -741,9 +741,7 @@ func TestMonitor(t *testing.T) {
 
 	// Connect to Redis
 	redisClient, err := redisx.NewClient(config.Redis{
-		Endpoints: []string{
-			container.DefaultAddress(),
-		},
+		Endpoint: container.DefaultAddress(),
 	})
 	require.NoError(t, err)
 

--- a/provider/redis/client.go
+++ b/provider/redis/client.go
@@ -13,7 +13,7 @@ import (
 // NewClient creates a new Redis client.
 func NewClient(option config.Redis) (rueidis.Client, error) {
 	clientOption := rueidis.ClientOption{
-		InitAddress:  option.Endpoints,
+		InitAddress:  []string{option.Endpoint},
 		Username:     option.Username,
 		Password:     option.Password,
 		DisableCache: option.DisableCache,


### PR DESCRIPTION
## Summary

use string type in redis config instead of array

will affect our prod deployment @incubator4 

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No