### PR TITLE
chore(makefile): add `make` commands for various Node services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+VERSION=$(shell git describe --tags --abbrev=0)
+COMMIT=$(shell git rev-parse --short HEAD)
+
 # Build this project and generate the binary in the ./build directory
 .PHONY: build
 build: generate
@@ -5,9 +8,6 @@ build: generate
 	go build \
 		-ldflags "-X github.com/rss3-network/node/internal/constant.Version=$(VERSION) -X github.com/rss3-network/node/internal/constant.Commit=$(COMMIT)" \
 		-o ./build/node ./cmd
-
-VERSION=$(shell git describe --tags --abbrev=0)
-COMMIT=$(shell git rev-parse --short HEAD)
 DOCKER_COMPOSE_FILE=./.devcontainer/docker-compose.yaml
 
 ifeq ($(VERSION),)

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,93 @@
 VERSION=$(shell git describe --tags --abbrev=0)
 COMMIT=$(shell git rev-parse --short HEAD)
+DOCKER_COMPOSE_FILE=./.devcontainer/docker-compose.yaml
 
 ifeq ($(VERSION),)
 	VERSION="0.0.0"
 endif
 
+# Run gocyclo to check the cyclomatic complexities of the top 10 most complex functions
 gocyclo:
 	go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -top 10 -ignore "_test|contract_" ./
 
+# Run gocognit to check cognitive complexities of the top 10 most complex functions
 gocognit:
 	go run github.com/uudashr/gocognit/cmd/gocognit@latest -top 10 -ignore "_test|contract_" ./
 
-# sort struct fields to reduce memory usage
+# Sort struct fields to reduce memory usage
 align:
 	go run github.com/dkorunic/betteralign/cmd/betteralign@latest -apply ./...
 
+# Run go generate to process any //go:generate directives
 generate:
 	go generate ./...
 
+# Run golangci-lint to lint the whole codebase, ensuring code quality
 lint:
 	go mod tidy
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.1 run
 
+# Run all tests with coverage and enabled race detection
 test:
 	go test -cover -race -v ./...
 
+# Start all docker services defined in the docker-compose file (located in the ./devcontainer directory)
+.PHONY: service_up
+service_up:
+	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d
+
+# Stop and remove all docker services defined in the docker-compose file (located in the ./devcontainer directory)
+.PHONY: service_down
+service_down:
+	docker-compose -f $(DOCKER_COMPOSE_FILE) down
+
+# Function to start a docker service defined in the docker-compose file
+define start_service
+	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d $(1)
+endef
+
+# Function to stop a docker service defined in the docker-compose file
+define stop_service
+	docker-compose -f $(DOCKER_COMPOSE_FILE) stop $(1)
+endef
+
+# Function to remove a docker service defined in the docker-compose file
+define remove_service
+	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f $(1)
+endef
+
+# Allow users to start a specific service by passing the SERVICE variable
+# Example: `make docker-start SERVICE=redis` Start the specific redis service in docker
+.PHONY: docker-start
+docker-start:
+	@if [ -z "$(SERVICE)" ]; then \
+		echo "SERVICE is not set. Usage: make docker-start SERVICE=<service-name>"; \
+		exit 1; \
+	fi
+	$(call start_service,$(SERVICE))
+
+# Allow users to stop a specific service by passing the SERVICE variable
+# Example: `make docker-stop SERVICE=redis` Stop the specific redis service in docker
+.PHONY: docker-stop
+docker-stop:
+	@if [ -z "$(SERVICE)" ]; then \
+		echo "SERVICE is not set. Usage: make docker-stop SERVICE=<service-name>"; \
+		exit 1; \
+	fi
+	$(call stop_service,$(SERVICE))
+
+# Allow users to remove a specific service by passing the SERVICE variable
+# Example: `make docker-remove SERVICE=redis` Remove the specific redis service in docker
+.PHONY: docker-remove
+docker-remove:
+	@if [ -z "$(SERVICE)" ]; then \
+		echo "SERVICE is not set. Usage: make docker-remove SERVICE=<service-name>"; \
+		exit 1; \
+	fi
+	$(call stop_service,$(SERVICE))
+	$(call remove_service,$(SERVICE))
+
+# Build this project and generate the binary in the ./build directory
 .PHONY: build
 build: generate
 	mkdir -p ./build
@@ -32,20 +95,24 @@ build: generate
 		-ldflags "-X github.com/rss3-network/node/internal/constant.Version=$(VERSION) -X github.com/rss3-network/node/internal/constant.Commit=$(COMMIT)" \
 		-o ./build/node ./cmd
 
+# Build a Docker image for this project
 image: generate
 	docker build \
     		--tag rss3-network/node:$(VERSION) \
     		.
 
-# Run a worker service locally to index and structure data from a decentralized source
-# into the RSS3 Protocol format. Use `make worker WORKER_ID=<worker-id>`.
-# Example: `make worker WORKER_ID=ethereum-uniswap` runs one worker to index and transform data from the Uniswap dApp source.
+
+
+
+# The following section details the make commands used to run various node services,
+# including worker, core, monitor, and broadcaster service.
 #
-# To use this command:
-# - Set the decentralized network endpoint (to which the decentralized source belongs) in the 'endpoint' section of deploy/config.yaml.
-# - Configure the decentralized data source component (e.g., a specific blockchain or its dApp) with the necessary parameters
-#   in the 'component' section of deploy/config.yaml.
-# - Use the worker ID of the component as WORKER_ID in the make command.
+# To run any services, you must have certain Docker services running, such as redis and cockroachdb
+# Use `make service_up` to start all required services using docker-compose
+# Use `make service_down` to remove all required services
+#
+# Run a worker service locally to index and structure data from a decentralized source
+# into the RSS3 Protocol format. Use `make worker WORKER_ID=<worker-id>`
 worker: generate
 	@if [ -z "$(WORKER_ID)" ]; then \
 		echo "WORKER_ID is not set. Usage: make worker WORKER_ID=<worker-id>"; \
@@ -55,35 +122,18 @@ worker: generate
 			--module=worker \
 			--worker.id=$(WORKER_ID)
 
-
-# Run the core service of the RSS3 Node locally, providing indexed data conforming to the RSS3 protocol to end users.
-# The node serves API requests on port 80 by default. Use `make core`.
-
-# Note: When routing API requests to check indexed data, include the routing group name in some paths.
-# For example, API services within 'internal/node/component/decentralized' may require adding '/decentralized' to
-# their paths, whereas API services within 'internal/node/component/info' may not.
+# Run the core service of the RSS3 Node locally, providing indexed data conforming to the RSS3 protocol to end users
 core: generate
 	ENVIRONMENT=development go run ./cmd \
 			--module=core
 
-# Start the monitor service to check the status of workers. Use `make monitor`.
+# Start the monitor service to check the status of workers. Use `make monitor`
 monitor: generate
 	ENVIRONMENT=development go run ./cmd \
 			--module=monitor
 
-
-# Start the broadcaster service to synchronize the node's status with a global indexer through heartbeats.
-# Use `make broadcaster`.
-#
-# To use this command:
-# - Generate the config.yaml for this service by registering an RSS3 node on the testnet at
-#   'https://explorer.testnet.rss3.io/nodes'. This YAML file includes essential information needed to start the service.
-# - Place the config.yaml file within the 'deploy' directory.
-#
-# Note:
-# - Set the environment type to 'beta' at the top of config.yaml. The global indexer will verify the node's
-#   accessibility. If the type is set to 'alpha', it will not be verified.
-# - Registering an RSS3 node may require staking a certain number of RSS3 tokens (if the node is in 'Alpha' type).
+# Start the broadcaster service to synchronize the node's status with a global indexer through heartbeats
+# Use `make broadcaster`
 broadcaster: generate
 	ENVIRONMENT=development go run ./cmd \
 			--module=broadcaster

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ image: generate
     		--tag rss3-network/node:$(VERSION) \
     		.
 
-# Run a worker service locally to index and structure data from 啊decentralized source
+# Run a worker service locally to index and structure data from a decentralized source
 # into the RSS3 Protocol format. Use `make worker WORKER_ID=<worker-id>`.
 # Example: `make worker WORKER_ID=ethereum-uniswap` runs one worker to index and transform data from the Uniswap dApp source.
 #
 # To use this command:
-# - Set the decentralized network endpoint (to which the data source belongs) in the 'endpoint' section of deploy/config.yaml.
+# - Set the decentralized network endpoint (to which the decentralized source belongs) in the 'endpoint' section of deploy/config.yaml.
 # - Configure the decentralized data source component (e.g., a specific blockchain or its dApp) with the necessary parameters
 #   in the 'component' section of deploy/config.yaml.
 # - Use the worker ID of the component as WORKER_ID in the make command.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+# Build this project and generate the binary in the ./build directory
+.PHONY: build
+build: generate
+	mkdir -p ./build
+	go build \
+		-ldflags "-X github.com/rss3-network/node/internal/constant.Version=$(VERSION) -X github.com/rss3-network/node/internal/constant.Commit=$(COMMIT)" \
+		-o ./build/node ./cmd
+
 VERSION=$(shell git describe --tags --abbrev=0)
 COMMIT=$(shell git rev-parse --short HEAD)
 DOCKER_COMPOSE_FILE=./.devcontainer/docker-compose.yaml
@@ -22,6 +30,10 @@ align:
 generate:
 	go generate ./...
 
+# Format the codebase by running gocognit and align
+.PHONY: fmt
+fmt: gocognit align
+
 # Run golangci-lint to lint the whole codebase, ensuring code quality
 lint:
 	go mod tidy
@@ -34,26 +46,26 @@ test:
 # Start all docker services defined in the docker-compose file (located in the ./devcontainer directory)
 .PHONY: service_up
 service_up:
-	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d
+	docker compose --project-name rss3-node -f $(DOCKER_COMPOSE_FILE) up -d
 
 # Stop and remove all docker services defined in the docker-compose file (located in the ./devcontainer directory)
 .PHONY: service_down
 service_down:
-	docker-compose -f $(DOCKER_COMPOSE_FILE) down
+	docker compose --project-name rss3-node -f $(DOCKER_COMPOSE_FILE) down
 
 # Function to start a docker service defined in the docker-compose file
 define start_service
-	docker-compose -f $(DOCKER_COMPOSE_FILE) up -d $(1)
+	docker compose --project-name rss3-node -f $(DOCKER_COMPOSE_FILE) up -d $(1)
 endef
 
 # Function to stop a docker service defined in the docker-compose file
 define stop_service
-	docker-compose -f $(DOCKER_COMPOSE_FILE) stop $(1)
+	docker compose --project-name rss3-node -f $(DOCKER_COMPOSE_FILE) stop $(1)
 endef
 
 # Function to remove a docker service defined in the docker-compose file
 define remove_service
-	docker-compose -f $(DOCKER_COMPOSE_FILE) rm -f $(1)
+	docker compose --project-name rss3-node -f $(DOCKER_COMPOSE_FILE) rm -f $(1)
 endef
 
 # Allow users to start a specific service by passing the SERVICE variable
@@ -86,14 +98,6 @@ docker-remove:
 	fi
 	$(call stop_service,$(SERVICE))
 	$(call remove_service,$(SERVICE))
-
-# Build this project and generate the binary in the ./build directory
-.PHONY: build
-build: generate
-	mkdir -p ./build
-	go build \
-		-ldflags "-X github.com/rss3-network/node/internal/constant.Version=$(VERSION) -X github.com/rss3-network/node/internal/constant.Commit=$(COMMIT)" \
-		-o ./build/node ./cmd
 
 # Build a Docker image for this project
 image: generate


### PR DESCRIPTION
## Summary

Add new make commands in the Makefile to simplify running the worker, core, monitor, and broadcaster services locally. This includes adding comments and notes for each command to provide clear instructions for developers.

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [ ] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No