### PR TITLE
chore: bring node operator api back and add info route

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -279,7 +279,7 @@
                 }
             }
         },
-        "/": {
+        "/info": {
             "get": {
                 "summary": "Get Node Status Info",
                 "description": "Retrieve node status details.",

--- a/internal/node/component/info/component.go
+++ b/internal/node/component/info/component.go
@@ -44,7 +44,8 @@ func NewComponent(_ context.Context, apiServer *echo.Echo, config *config.File, 
 		httpClient:          http.DefaultClient,
 	}
 
-	apiServer.GET("/", c.GetNodeInfo)
+	apiServer.GET("/", c.GetNodeOperator)
+	apiServer.GET("/info", c.GetNodeInfo)
 	apiServer.GET("/version", c.GetVersion)
 	apiServer.GET("/activity_count", c.GetActivityCount)
 	apiServer.GET("/workers_status", c.GetWorkersStatus)

--- a/internal/node/component/info/handler_node.go
+++ b/internal/node/component/info/handler_node.go
@@ -76,6 +76,24 @@ type Reward struct {
 	RequestCounts    decimal.Decimal `json:"request_counts"`
 }
 
+// GetNodeOperator returns the node information.
+func (c *Component) GetNodeOperator(ctx echo.Context) error {
+	go c.CollectMetric(ctx.Request().Context(), ctx.Request().RequestURI, "info")
+
+	zap.L().Debug("get node info", zap.String("request.ip", ctx.Request().RemoteAddr))
+
+	// Get Operator address info
+	evmAddress := common.Address{}
+
+	if !lo.IsEmpty(c.config.Discovery.Operator.EvmAddress) {
+		evmAddress = c.config.Discovery.Operator.EvmAddress
+	}
+
+	response := fmt.Sprintf("This is an RSS3 Node operated by %s.", evmAddress)
+
+	return ctx.JSON(http.StatusOK, response)
+}
+
 // GetNodeInfo returns the node information.
 func (c *Component) GetNodeInfo(ctx echo.Context) error {
 	go c.CollectMetric(ctx.Request().Context(), ctx.Request().RequestURI, "info")


### PR DESCRIPTION
## Summary

bring node operator api back and add info route

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No