### PR TITLE
feat: add index count in workers_status api

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -279,9 +279,29 @@
                 }
             }
         },
+        "/workers_status": {
+            "get": {
+                "summary": "Get Node Worker Status",
+                "description": "Retrieve node worker status details.",
+                "tags": [
+                    "Info"
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/WorkerInfoResponse"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalError"
+                    }
+                }
+            }
+        },
         "/info": {
             "get": {
-                "summary": "Get Node Status Info",
+                "summary": "Get Node Status",
                 "description": "Retrieve node status details.",
                 "tags": [
                     "Info"
@@ -751,6 +771,14 @@
                 },
                 "type": "object"
             },
+            "WorkerInfoResponse": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/WorkerInfo"
+                    }
+                },
+                "type": "object"
+            },
             "NodeInfo": {
                 "properties": {
                     "operator": {
@@ -919,6 +947,128 @@
                     "request_counts": {
                         "description": "The request counts of reward.",
                         "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "WorkerInfo": {
+                "properties": {
+                    "decentralized": {
+                        "description": "The decentralized worker status.",
+                        "items": {
+                            "$ref": "#/components/schemas/WorkerStatus"
+                        },
+                        "type": "array"
+                    },
+                    "rss": {
+                        "description": "The rss worker status.",
+                        "items": {
+                            "$ref": "#/components/schemas/WorkerStatus"
+                        },
+                        "type": "array"
+                    },
+                    "federated": {
+                        "description": "The federated worker status.",
+                        "items": {
+                            "$ref": "#/components/schemas/WorkerStatus"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "example": {
+                    "decentralized": [
+                        {
+                            "network": "ethereum",
+                            "worker": "vsl",
+                            "tags": [
+                                "transaction"
+                            ],
+                            "platform": "VSL",
+                            "status": "Ready",
+                            "remote_state": 20416809,
+                            "indexed_state": 20416808,
+                            "index_count": 1174
+                        },
+                        {
+                            "network": "polygon",
+                            "worker": "curve",
+                            "tags": [
+                                "exchange",
+                                "transaction"
+                            ],
+                            "platform": "Curve",
+                            "status": "Ready",
+                            "remote_state": 59974392,
+                            "indexed_state": 59974383,
+                            "index_count": 2138457
+                        },
+                        {
+                            "network": "arweave",
+                            "worker": "mirror",
+                            "tags": [
+                                "social"
+                            ],
+                            "platform": "Mirror",
+                            "status": "Ready",
+                            "remote_state": 1475386,
+                            "indexed_state": 1475385,
+                            "index_count": 697886
+                        }
+                    ],
+                    "rss": [
+                        {
+                            "network": "rss",
+                            "worker": "rsshub",
+                            "tags": [
+                                "rss"
+                            ],
+                            "platform": "Unknown",
+                            "status": "Ready",
+                            "remote_state": 0,
+                            "indexed_state": 0
+                        }
+                    ],
+                    "federated": null
+                }
+            },
+            "WorkerStatus": {
+                "description": "The status of the worker.",
+                "properties": {
+                    "network": {
+                        "description": "The network which the worker belongs to.",
+                        "type": "string"
+                    },
+                    "worker": {
+                        "description": "The worker name.",
+                        "type": "string"
+                    },
+                    "tags": {
+                        "description": "The tag of worker.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "platform": {
+                        "description": "The platform of worker.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "The indexing status of worker.",
+                        "type": "string"
+                    },
+                    "remote_state": {
+                        "description": "The remote state of worker.",
+                        "type": "integer"
+                    },
+                    "indexed_state": {
+                        "description": "The indexed state of worker.",
+                        "type": "integer"
+                    },
+                    "index_count": {
+                        "description": "The index count of worker.",
+                        "type": "integer"
                     }
                 },
                 "type": "object"
@@ -1116,6 +1266,16 @@
                     "application/json": {
                         "schema": {
                             "$ref": "#/components/schemas/NodeInfoResponse"
+                        }
+                    }
+                }
+            },
+            "WorkerInfoResponse": {
+                "description": "The request was successful.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/WorkerInfoResponse"
                         }
                     }
                 }

--- a/internal/node/component/info/handler_worker.go
+++ b/internal/node/component/info/handler_worker.go
@@ -176,6 +176,7 @@ func (c *Component) fetchWorkerInfo(ctx context.Context, module *config.Module) 
 		WorkerProgress: monitor.WorkerProgress{
 			RemoteState:  workerProgress.RemoteState,
 			IndexedState: workerProgress.IndexedState,
+			IndexCount:   workerProgress.IndexCount,
 		},
 	}
 

--- a/internal/node/monitor/monitor_mock.go
+++ b/internal/node/monitor/monitor_mock.go
@@ -75,7 +75,7 @@ func (m *Monitor) processMockWorker(ctx context.Context, w *config.Module, curre
 	}
 
 	//	update worker progress (state)
-	if err := m.UpdateWorkerProgress(ctx, w.ID, ConstructWorkerProgress(currentWorkerState, targetWorkerState, latestWorkerState)); err != nil {
+	if err := m.UpdateWorkerProgress(ctx, w.ID, ConstructWorkerProgress(currentWorkerState, targetWorkerState, latestWorkerState, 0)); err != nil {
 		return fmt.Errorf("update worker progress: %w", err)
 	}
 

--- a/internal/node/monitor/monitor_test.go
+++ b/internal/node/monitor/monitor_test.go
@@ -1017,7 +1017,7 @@ func TestMonitor(t *testing.T) {
 				require.NoError(t, err)
 
 				// update worker progress
-				err = instance.UpdateWorkerProgress(ctx, testcase.arguments.config.Component.Decentralized[0].ID, monitor.ConstructWorkerProgress(testcase.arguments.lastState, testcase.arguments.targetState, testcase.arguments.latestState))
+				err = instance.UpdateWorkerProgress(ctx, testcase.arguments.config.Component.Decentralized[0].ID, monitor.ConstructWorkerProgress(testcase.arguments.lastState, testcase.arguments.targetState, testcase.arguments.latestState, 0))
 				require.NoError(t, err)
 
 				// run monitor

--- a/internal/node/monitor/server.go
+++ b/internal/node/monitor/server.go
@@ -28,7 +28,7 @@ type Monitor struct {
 
 func (m *Monitor) Run(ctx context.Context) error {
 	if m.databaseClient != nil && m.redisClient != nil {
-		_, err := m.cron.AddFunc("@every 15s", func() {
+		_, err := m.cron.AddFunc("@every 15m", func() {
 			if err := m.MonitorWorkerStatus(ctx); err != nil {
 				return
 			}

--- a/internal/node/monitor/server.go
+++ b/internal/node/monitor/server.go
@@ -28,7 +28,7 @@ type Monitor struct {
 
 func (m *Monitor) Run(ctx context.Context) error {
 	if m.databaseClient != nil && m.redisClient != nil {
-		_, err := m.cron.AddFunc("@every 15m", func() {
+		_, err := m.cron.AddFunc("@every 15s", func() {
 			if err := m.MonitorWorkerStatus(ctx); err != nil {
 				return
 			}


### PR DESCRIPTION
## Summary

Add the `index_count` field to `/workers_status` without modifying existing fields. This change will not affect GI-related APIs. @brucexc 

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No