### PR TITLE
feat: add bearer token auth for /decentralized and /rss routers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,7 @@ type Operator struct {
 type Server struct {
 	Endpoint              string `mapstructure:"endpoint"`
 	GlobalIndexerEndpoint string `mapstructure:"global_indexer_endpoint"`
+	AccessToken           string `mapstructure:"access_token"`
 }
 
 type Component struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,6 +28,7 @@ discovery:
     server:
       endpoint: https://node.mydomain.com/
       global_indexer_endpoint: https://gi.rss3.dev/
+      access_token: test
 endpoints:
     ethereum:
       url: https://rpc.ankr.com/eth
@@ -98,7 +99,8 @@ component:
     },
     "server": {
       "endpoint": "https://node.mydomain.com/",
-      "global_indexer_endpoint": "https://gi.rss3.dev/"
+      "global_indexer_endpoint": "https://gi.rss3.dev/",
+      "access_token": "test"
     }
   },
   "database": {
@@ -184,6 +186,7 @@ url = "https://rpc.ankr.com/eth"
 [discovery.server]
 endpoint = "https://node.mydomain.com/"
 global_indexer_endpoint = "https://gi.rss3.dev/"
+access_token = "test"
 
 [database]
 driver = "cockroachdb"
@@ -262,6 +265,7 @@ var configFileExpected = &File{
 		Server: &Server{
 			Endpoint:              "https://node.mydomain.com/",
 			GlobalIndexerEndpoint: "https://gi.rss3.dev/",
+			AccessToken:           "test",
 		},
 	},
 	Component: &Component{

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -24,6 +24,11 @@
                 "tags": [
                     "Decentralized"
                 ],
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/activity_id_path"
@@ -57,6 +62,11 @@
                 "description": "This endpoint retrieves the activities associated with a specified account in the decentralized system. You can use various query parameters to filter and paginate the results, including limits on the number of activities and actions, timestamps, success status, direction, and more.",
                 "tags": [
                     "Decentralized"
+                ],
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
                 ],
                 "parameters": [
                     {
@@ -119,6 +129,11 @@
                 "tags": [
                     "Decentralized"
                 ],
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
                 "requestBody": {
                     "$ref": "#/components/requestBodies/BatchGetAccountsActivities"
                 },
@@ -141,6 +156,11 @@
                 "description": "Retrieve a list of activities from the specified decentralized network. This endpoint allows you to filter activities by various parameters such as limit, timestamp, success status, and more.",
                 "tags": [
                     "Decentralized"
+                ],
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
                 ],
                 "parameters": [
                     {
@@ -200,6 +220,11 @@
                 "tags": [
                     "Decentralized"
                 ],
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/platform_path"
@@ -257,6 +282,11 @@
                 "description": "Retrieve details from the specified RSS path.",
                 "tags": [
                     "RSS"
+                ],
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
                 ],
                 "parameters": [
                     {
@@ -321,6 +351,12 @@
         }
     },
     "components": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer"
+            }
+        },
         "parameters": {
             "activity_id_path": {
                 "description": "Retrieve details for the specified activity ID",

--- a/internal/node/broadcaster/broadcaster.go
+++ b/internal/node/broadcaster/broadcaster.go
@@ -16,12 +16,13 @@ import (
 
 func (b *Broadcaster) Register(ctx context.Context) error {
 	request := RegisterNodeRequest{
-		Address:   b.config.Discovery.Operator.EvmAddress,
-		Signature: b.config.Discovery.Operator.Signature,
-		Endpoint:  b.config.Discovery.Server.Endpoint,
-		Stream:    b.config.Stream,
-		Config:    b.config.Component,
-		Type:      b.config.Type,
+		Address:     b.config.Discovery.Operator.EvmAddress,
+		Signature:   b.config.Discovery.Operator.Signature,
+		Endpoint:    b.config.Discovery.Server.Endpoint,
+		AccessToken: b.config.Discovery.Server.AccessToken,
+		Stream:      b.config.Stream,
+		Config:      b.config.Component,
+		Type:        b.config.Type,
 	}
 
 	var response any
@@ -104,12 +105,13 @@ func (b *Broadcaster) sendRequest(ctx context.Context, path string, values url.V
 }
 
 type RegisterNodeRequest struct {
-	Address   common.Address    `json:"address" validate:"required"`
-	Signature string            `json:"signature" validate:"required"`
-	Endpoint  string            `json:"endpoint" validate:"required"`
-	Stream    *config.Stream    `json:"stream,omitempty"`
-	Config    *config.Component `json:"config,omitempty"`
-	Type      string            `json:"type" validate:"required"`
+	Address     common.Address    `json:"address" validate:"required"`
+	Signature   string            `json:"signature" validate:"required"`
+	Endpoint    string            `json:"endpoint" validate:"required"`
+	AccessToken string            `json:"access_token,omitempty"`
+	Stream      *config.Stream    `json:"stream,omitempty"`
+	Config      *config.Component `json:"config,omitempty"`
+	Type        string            `json:"type" validate:"required"`
 }
 
 type NodeHeartbeatRequest struct {

--- a/internal/node/component/decentralized/component.go
+++ b/internal/node/component/decentralized/component.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rss3-network/node/internal/constant"
 	"github.com/rss3-network/node/internal/database"
 	"github.com/rss3-network/node/internal/node/component"
+	"github.com/rss3-network/node/internal/node/component/middleware"
 	"github.com/rss3-network/node/provider/ethereum/etherface"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
@@ -54,6 +55,9 @@ func NewComponent(_ context.Context, apiServer *echo.Echo, config *config.File, 
 	}
 
 	group := apiServer.Group(fmt.Sprintf("/%s", Name))
+
+	// Add middleware for bearer token authentication
+	group.Use(middleware.BearerAuth(config.Discovery.Server.AccessToken))
 
 	group.GET("/tx/:id", c.GetActivity)
 	group.GET("/:account", c.GetAccountActivities)

--- a/internal/node/component/middleware/auth.go
+++ b/internal/node/component/middleware/auth.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+// BearerAuth middleware for bearer token authentication
+func BearerAuth(accessToken string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			authHeader := c.Request().Header.Get("Authorization")
+			if authHeader == "" {
+				return echo.NewHTTPError(http.StatusUnauthorized, "Missing Authorization header")
+			}
+
+			// Check if the header starts with "Bearer "
+			if !strings.HasPrefix(authHeader, "Bearer ") {
+				return echo.NewHTTPError(http.StatusUnauthorized, "Invalid Authorization header format")
+			}
+
+			// Extract the token
+			token := strings.TrimPrefix(authHeader, "Bearer ")
+
+			// Verify the token
+			if token != accessToken {
+				return echo.NewHTTPError(http.StatusUnauthorized, "Invalid access token")
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -74,7 +74,7 @@ func NewCoreService(ctx context.Context, config *config.File, databaseClient dat
 	node.components = append(node.components, &infoComponent)
 
 	if len(config.Component.RSS) > 0 {
-		rssComponent := rss.NewComponent(ctx, apiServer, config.Component.RSS)
+		rssComponent := rss.NewComponent(ctx, apiServer, config)
 		node.components = append(node.components, &rssComponent)
 	}
 


### PR DESCRIPTION
## Summary

It adds bearer token authentication for the `/decentralized` and `/rss` APIs.

should resolve #345 

**IMPORTANT**

Implementation requires addressing issue https://github.com/RSS3-Network/Node-Automated-Deployer/issues/22. @STRRL 

Before moving to production, GI must update the node API invocation logic to include authentication. @brucexc 

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No