### PR TITLE
feat: add start timestamp to farcaster

### DIFF
--- a/internal/engine/source/farcaster/data_source.go
+++ b/internal/engine/source/farcaster/data_source.go
@@ -639,7 +639,9 @@ func NewSource(config *config.Module, checkpoint *engine.Checkpoint, databaseCli
 
 	zap.L().Info("apply option", zap.Any("option", instance.option))
 
-	instance.startFarcasterTimestamp = farcaster.CovertTimestampToFarcasterTime(instance.option.TimestampStart.Int64())
+	if instance.option.TimestampStart != nil {
+		instance.startFarcasterTimestamp = farcaster.CovertTimestampToFarcasterTime(instance.option.TimestampStart.Int64())
+	}
 
 	return &instance, nil
 }

--- a/internal/engine/source/farcaster/data_source.go
+++ b/internal/engine/source/farcaster/data_source.go
@@ -28,12 +28,13 @@ const (
 var _ engine.DataSource = (*dataSource)(nil)
 
 type dataSource struct {
-	config          *config.Module
-	option          *Option
-	farcasterClient farcaster.Client
-	databaseClient  database.Client
-	state           State
-	pendingState    State
+	config                  *config.Module
+	option                  *Option
+	farcasterClient         farcaster.Client
+	databaseClient          database.Client
+	state                   State
+	pendingState            State
+	startFarcasterTimestamp uint32
 }
 
 func (s *dataSource) Network() network.Network {
@@ -114,9 +115,7 @@ func (s *dataSource) pollCasts(ctx context.Context, tasksChan chan<- *engine.Tas
 
 	// Poll casts by fid until backfill is complete.
 	for !s.state.CastsBackfill {
-		err := s.pollCastsByFid(ctx, lo.ToPtr(int64(s.pendingState.CastsFid)), "", tasksChan)
-
-		if err != nil {
+		if err := s.pollCastsByFid(ctx, lo.ToPtr(int64(s.pendingState.CastsFid)), "", tasksChan); err != nil {
 			return err
 		}
 
@@ -144,13 +143,18 @@ func (s *dataSource) pollCastsByFid(ctx context.Context, fid *int64, pageToken s
 			return err
 		}
 
+		messages := lo.Filter(castsByFidResponse.Messages, func(message farcaster.Message, _ int) bool {
+			return message.Data.Timestamp >= s.startFarcasterTimestamp
+		})
+
 		// Build tasks from the fetched casts and send them to the tasks channel.
-		tasks := s.buildFarcasterMessageTasks(ctx, castsByFidResponse.Messages)
+		tasks := s.buildFarcasterMessageTasks(ctx, messages)
 
 		tasksChan <- tasks
 
-		// If the fetched casts do not have a next page token, return nil
-		if castsByFidResponse.NextPageToken == "" {
+		// If the fetched casts do not have a next page token
+		// or the number of messages is less than the number of fetched messages
+		if castsByFidResponse.NextPageToken == "" || len(messages) < len(castsByFidResponse.Messages) {
 			return nil
 		}
 		// Update the page token for the next iteration
@@ -178,9 +182,7 @@ func (s *dataSource) pollReactions(ctx context.Context, tasksChan chan<- *engine
 
 	// Poll reactions by fid until backfill is complete.
 	for !s.state.ReactionsBackfill {
-		err := s.pollReactionsByFid(ctx, lo.ToPtr(int64(s.pendingState.ReactionsFid)), "", tasksChan)
-
-		if err != nil {
+		if err := s.pollReactionsByFid(ctx, lo.ToPtr(int64(s.pendingState.ReactionsFid)), "", tasksChan); err != nil {
 			return err
 		}
 
@@ -198,7 +200,7 @@ func (s *dataSource) pollReactions(ctx context.Context, tasksChan chan<- *engine
 	return nil
 }
 
-// pollCastsByFid polls reactions by fid from the Farcaster Hub and send tasks to tasksChan.
+// pollReactionsByFid polls reactions by fid from the Farcaster Hub and send tasks to tasksChan.
 func (s *dataSource) pollReactionsByFid(ctx context.Context, fid *int64, pageToken string, tasksChan chan<- *engine.Tasks) error {
 	for {
 		// Fetch reactions by fid.
@@ -207,12 +209,18 @@ func (s *dataSource) pollReactionsByFid(ctx context.Context, fid *int64, pageTok
 		if err != nil {
 			return err
 		}
+
+		messages := lo.Filter(reactionsByFidResponse.Messages, func(message farcaster.Message, _ int) bool {
+			return message.Data.Timestamp >= s.startFarcasterTimestamp
+		})
+
 		// Build tasks from the fetched reactions and send them to the tasks channel.
-		tasks := s.buildFarcasterMessageTasks(ctx, reactionsByFidResponse.Messages)
+		tasks := s.buildFarcasterMessageTasks(ctx, messages)
 
 		tasksChan <- tasks
-		// If the fetched reactions do not have a next page token, return nil
-		if reactionsByFidResponse.NextPageToken == "" {
+		// If the fetched reactions do not have a next page token
+		// or the number of messages is less than the number of fetched messages
+		if reactionsByFidResponse.NextPageToken == "" || len(messages) < len(reactionsByFidResponse.Messages) {
 			return nil
 		}
 		// Update the page token for the next iteration
@@ -625,11 +633,13 @@ func NewSource(config *config.Module, checkpoint *engine.Checkpoint, databaseCli
 		pendingState:   state, // Default pending state is equal to current state.
 	}
 
-	if instance.option, err = NewOption(config.Parameters); err != nil {
+	if instance.option, err = NewOption(config.Network, config.Parameters); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
 	zap.L().Info("apply option", zap.Any("option", instance.option))
+
+	instance.startFarcasterTimestamp = farcaster.CovertTimestampToFarcasterTime(instance.option.TimestampStart.Int64())
 
 	return &instance, nil
 }

--- a/internal/engine/source/farcaster/option.go
+++ b/internal/engine/source/farcaster/option.go
@@ -18,7 +18,9 @@ func NewOption(n network.Network, parameters *config.Parameters) (*Option, error
 	var option Option
 
 	if parameters == nil {
-		return &option, nil
+		return &Option{
+			TimestampStart: parameter.CurrentNetworkStartBlock[n],
+		}, nil
 	}
 
 	if err := parameters.Decode(&option); err != nil {

--- a/internal/engine/source/farcaster/option.go
+++ b/internal/engine/source/farcaster/option.go
@@ -1,14 +1,20 @@
 package farcaster
 
 import (
+	"math/big"
+
 	"github.com/rss3-network/node/config"
+	"github.com/rss3-network/node/config/parameter"
+	"github.com/rss3-network/protocol-go/schema/network"
 )
 
 type Option struct {
 	APIKey *string `json:"api_key" mapstructure:"api_key"`
+	// TimestampStart is the Farcaster seconds timestamp that the worker should start from.
+	TimestampStart *big.Int `json:"timestamp_start" mapstructure:"timestamp_start"`
 }
 
-func NewOption(parameters *config.Parameters) (*Option, error) {
+func NewOption(n network.Network, parameters *config.Parameters) (*Option, error) {
 	var option Option
 
 	if parameters == nil {
@@ -17,6 +23,10 @@ func NewOption(parameters *config.Parameters) (*Option, error) {
 
 	if err := parameters.Decode(&option); err != nil {
 		return nil, err
+	}
+
+	if option.TimestampStart == nil {
+		option.TimestampStart = parameter.CurrentNetworkStartBlock[n]
 	}
 
 	return &option, nil

--- a/provider/farcaster/client.go
+++ b/provider/farcaster/client.go
@@ -297,6 +297,11 @@ func CovertFarcasterTimeToTimestamp(timestamp int64) int64 {
 	return timestamp + FarcasterEpoch
 }
 
+// CovertTimestampToFarcasterTime Converts a Unix timestamp to a Farcaster seconds timestamp.
+func CovertTimestampToFarcasterTime(timestamp int64) uint32 {
+	return uint32(timestamp) - FarcasterEpoch
+}
+
 // ConvertEventIDToTimestampMilli Convert the timestampMilli from a farcaster event ID.
 func ConvertEventIDToTimestampMilli(eventID uint64) uint64 {
 	timestampMilliMask := ^uint64((1 << SequenceBits) - 1)

--- a/provider/farcaster/client_test.go
+++ b/provider/farcaster/client_test.go
@@ -734,6 +734,16 @@ func TestClient_CovertFarcasterTimeToTimestamp(t *testing.T) {
 	})
 }
 
+func TestClient_CovertTimestampToFarcasterTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("covert timestamp to Farcaster time", func(t *testing.T) {
+		t.Parallel()
+
+		require.Equal(t, farcaster.CovertTimestampToFarcasterTime(int64(1687683881)), uint32(78224681))
+	})
+}
+
 func TestClient_ConvertEventIDToTimestampMilli(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
To add a start timestamp to Farcaster and only retrieve data after the start timestamp.

`Start timestamp is in seconds`

related to https://github.com/RSS3-Network/Node/issues/485

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
