### PR TITLE
feat: add `networks/config` api that returns all config details

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -349,16 +349,16 @@
                 }
             }
         },
-        "/networks/endpoint_config": {
+        "/networks/config": {
             "get": {
-                "summary": "Get Endpoint config options",
-                "description": "Retrieve endpoint config options and descriptions.",
+                "summary": "Get worker config options",
+                "description": "Retrieve worker config options and descriptions.",
                 "tags": [
                     "Info"
                 ],
                 "responses": {
                     "200": {
-                        "$ref": "#/components/responses/EndpointConfigResponse"
+                        "$ref": "#/components/responses/NetworkConfigResponse"
                     },
                     "400": {
                         "$ref": "#/components/responses/BadRequest"
@@ -827,10 +827,10 @@
                 },
                 "type": "object"
             },
-            "EndpointConfigResponse": {
+            "NetworkConfigResponse": {
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/EndpointConfig"
+                        "$ref": "#/components/schemas/NetworkConfig"
                     }
                 },
                 "type": "object",
@@ -1125,6 +1125,47 @@
                     "federated": null
                 }
             },
+            "NetworkConfig": {
+                "description": "The worker config details by source.",
+                "type": "object",
+                "properties": {
+                    "rss": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/NetworkConfigDetail"
+                        }
+                    },
+                    "decentralized": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/NetworkConfigDetail"
+                        }
+                    },
+                    "federated": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/NetworkConfigDetail"
+                        }
+                    }
+                }
+            },
+            "NetworkConfigDetail": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "endpoint_configs": {
+                        "$ref": "#/components/schemas/EndpointConfig"
+                    },
+                    "worker_configs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/WorkerConfig"
+                        }
+                    }
+                }
+            },
             "EndpointConfig": {
                 "description": "The endpoint options and config details of the worker.",
                 "properties": {
@@ -1139,6 +1180,106 @@
                     }
                 },
                 "type": "object"
+            },
+            "WorkerConfig": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "network": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "worker": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "endpoint": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "ipfs_gateways": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "parameters": {
+                        "$ref": "#/components/schemas/Parameters"
+                    },
+                    "minimum_resource": {
+                        "$ref": "#/components/schemas/MinimumResource"
+                    }
+                }
+            },
+            "Parameters": {
+                "type": "object",
+                "properties": {
+                    "block_start": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "block_target": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "concurrent_block_requests": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "block_batch_size": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "receipts_batch_size": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "block_receipts_batch_size": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "api_key": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    },
+                    "authentication": {
+                        "$ref": "#/components/schemas/Authentication"
+                    },
+                    "kafka_topic": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    }
+                }
+            },
+            "Authentication": {
+                "type": "object",
+                "properties": {
+                    "access_key": {
+                        "$ref": "#/components/schemas/ConfigDetail"
+                    }
+                }
+            },
+            "MinimumResource": {
+                "type": "object",
+                "properties": {
+                    "cpu_core": {
+                        "type": "number",
+                        "format": "float"
+                    },
+                    "memory_in_gb": {
+                        "type": "number",
+                        "format": "float"
+                    },
+                    "disk_space_in_gb": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "ConfigDetail": {
+                "type": "object",
+                "required": ["is_required", "type", "value", "description"],
+                "properties": {
+                    "is_required": {
+                        "type": "boolean"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    }
+                }
             },
             "WorkerStatus": {
                 "description": "The status of the worker.",
@@ -1184,24 +1325,6 @@
                     }
                 },
                 "type": "object"
-            },
-            "ConfigDetail": {
-                "type": "object",
-                "required": ["is_required", "type", "value", "description"],
-                "properties": {
-                    "is_required": {
-                        "type": "boolean"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    }
-                }
             },
             "Calldata": {
                 "description": "Represents the call data associated with an activity.",
@@ -1400,12 +1523,12 @@
                     }
                 }
             },
-            "EndpointConfigResponse": {
+            "NetworkConfigResponse": {
                 "description": "The request was successful.",
                 "content": {
                     "application/json": {
                         "schema": {
-                            "$ref": "#/components/schemas/EndpointConfigResponse"
+                            "$ref": "#/components/schemas/NetworkConfigResponse"
                         }
                     }
                 }

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/redis/rueidis v1.0.45
 	github.com/redis/rueidis/rueidiscompat v1.0.45
-	github.com/rss3-network/protocol-go v0.5.8
+	github.com/rss3-network/protocol-go v0.5.9
 	github.com/spf13/afero v1.11.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tidwall/sjson v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
-github.com/rss3-network/protocol-go v0.5.8 h1:w3XCFrqvNTXGHVCKM50rdmhgnj7BxY0+7FSGVvGCJeY=
-github.com/rss3-network/protocol-go v0.5.8/go.mod h1:npcyduWt86uVbIi77xQaYk8eqltI9XNjk1FMGpjyIq0=
+github.com/rss3-network/protocol-go v0.5.9 h1:PGIpC5XlmQu5JA94go5dmHOsf/JRd/iW4ajxtnTi6uA=
+github.com/rss3-network/protocol-go v0.5.9/go.mod h1:npcyduWt86uVbIi77xQaYk8eqltI9XNjk1FMGpjyIq0=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/node/component/info/component.go
+++ b/internal/node/component/info/component.go
@@ -51,11 +51,7 @@ func NewComponent(_ context.Context, apiServer *echo.Echo, config *config.File, 
 	apiServer.GET("/workers_status", c.GetWorkersStatus)
 
 	networks := apiServer.Group("/networks")
-
-	networks.GET("", c.GetNetworksHandler)
-	networks.GET("/endpoint_config", c.GetEndpointConfig)
-	networks.GET("/:network/list_workers", c.GetWorkersByNetwork)
-	networks.GET("/:network/workers/:worker", c.GetWorkerConfig)
+	networks.GET("/config", c.GetNetworkConfig)
 
 	if err := c.InitMeter(); err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary

add `networks/config` api that returns all config details so the explorer don't need to invoke multiple apis

**BE CAREFUL**

- will affect GI APIs @brucexc 
- will affect Explorer @songkeys 
- will affect build-readme github actions @pseudoyu 

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No