### PR TITLE
chore: remove rsshub endpoint default value

### DIFF
--- a/internal/node/component/info/handler_network.go
+++ b/internal/node/component/info/handler_network.go
@@ -65,7 +65,6 @@ func getNetworkConfigDetailForRSS(source network.Source) NetworkConfigDetailForR
 
 	if workerConfig.EndpointID != nil {
 		workerConfig.EndpointID.Type = URLType
-		workerConfig.EndpointID.Value = "https://your-rsshub-endpoint"
 	}
 
 	networkDetail.WorkerConfig = workerConfig


### PR DESCRIPTION
## Summary

remove rsshub endpoint default value

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No