### PR TITLE
feat: use both `/` and `/operators` routes

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -577,7 +577,7 @@
                 }
             }
         },
-        "/workers_status": {
+        "/operators/workers_status": {
             "get": {
                 "summary": "Get Node Worker Status",
                 "description": "Retrieve node worker status details.",
@@ -597,7 +597,7 @@
                 }
             }
         },
-        "/info": {
+        "/operators/info": {
             "get": {
                 "summary": "Get Node Status",
                 "description": "Retrieve node status details.",
@@ -1410,9 +1410,6 @@
                         "properties": {
                             "id": {
                                 "type": "string"
-                            },
-                            "endpoint_configs": {
-                                "$ref": "#/components/schemas/Endpoint"
                             },
                             "worker_configs": {
                                 "$ref": "#/components/schemas/WorkerConfig"

--- a/internal/node/component/info/component.go
+++ b/internal/node/component/info/component.go
@@ -44,18 +44,10 @@ func NewComponent(_ context.Context, apiServer *echo.Echo, config *config.File, 
 		httpClient:          http.DefaultClient,
 	}
 
-	// Register routes both at root and under /operators prefix
-	apiServer.GET("/", c.GetNodeOperator)
-	apiServer.GET("/info", c.GetNodeInfo)
-	apiServer.GET("/version", c.GetVersion)
-	apiServer.GET("/activity_count", c.GetActivityCount)
-	apiServer.GET("/workers_status", c.GetWorkersStatus)
-
 	operators := apiServer.Group("/operators")
 
 	operators.GET("", c.GetNodeOperator)
 	operators.GET("/info", c.GetNodeInfo)
-	operators.GET("/version", c.GetVersion)
 	operators.GET("/activity_count", c.GetActivityCount)
 	operators.GET("/workers_status", c.GetWorkersStatus)
 

--- a/internal/node/component/info/component.go
+++ b/internal/node/component/info/component.go
@@ -44,11 +44,20 @@ func NewComponent(_ context.Context, apiServer *echo.Echo, config *config.File, 
 		httpClient:          http.DefaultClient,
 	}
 
+	// Register routes both at root and under /operators prefix
 	apiServer.GET("/", c.GetNodeOperator)
 	apiServer.GET("/info", c.GetNodeInfo)
 	apiServer.GET("/version", c.GetVersion)
 	apiServer.GET("/activity_count", c.GetActivityCount)
 	apiServer.GET("/workers_status", c.GetWorkersStatus)
+
+	operators := apiServer.Group("/operators")
+
+	operators.GET("", c.GetNodeOperator)
+	operators.GET("/info", c.GetNodeInfo)
+	operators.GET("/version", c.GetVersion)
+	operators.GET("/activity_count", c.GetActivityCount)
+	operators.GET("/workers_status", c.GetWorkersStatus)
 
 	networks := apiServer.Group("/networks")
 	networks.GET("/config", c.GetNetworkConfig)

--- a/internal/node/component/info/handler_node.go
+++ b/internal/node/component/info/handler_node.go
@@ -171,15 +171,6 @@ func (c *Component) GetNodeInfo(ctx echo.Context) error {
 	})
 }
 
-// GetVersion returns the version of the network component.
-func (c *Component) GetVersion(ctx echo.Context) error {
-	version := c.buildVersion()
-
-	return ctx.JSON(http.StatusOK, VersionResponse{
-		Data: version,
-	})
-}
-
 func (c *Component) buildVersion() Version {
 	tag, commit := constant.BuildVersionDetail()
 


### PR DESCRIPTION
## Summary

Add `/operators` route group.

May I only keep `/operators` route and GI will invoke different routes based on Node version or I just includes two versions? @brucexc 

And openapi docs is blocked by #599 @incubator4 

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No