### PR TITLE
fix: monitor rsshub check logic

### DIFF
--- a/internal/node/monitor/server.go
+++ b/internal/node/monitor/server.go
@@ -115,19 +115,12 @@ func initNetworkClient(m *config.Module) (Client, error) {
 // NewMonitor creates a new monitor instance.
 func NewMonitor(_ context.Context, configFile *config.File, databaseClient database.Client, redisClient rueidis.Client, networkParamsCaller *vsl.NetworkParamsCaller, settlementCaller *vsl.SettlementCaller) (*Monitor, error) {
 	totalModules := len(configFile.Component.Decentralized) + len(configFile.Component.Federated)
-	if configFile.Component.RSS != nil {
-		totalModules++
-	}
 
 	modules := make([]*config.Module, 0, totalModules)
 
 	modules = append(modules, configFile.Component.Decentralized...)
 
 	modules = append(modules, configFile.Component.Federated...)
-
-	if configFile.Component.RSS != nil {
-		modules = append(modules, configFile.Component.RSS)
-	}
 
 	clients := make(map[network.Network]Client)
 


### PR DESCRIPTION
## Summary

remove rsshub config check logic from monitor

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No