### PR TITLE
fix: transfer value is zero

### DIFF
--- a/internal/engine/worker/decentralized/core/ethereum/worker.go
+++ b/internal/engine/worker/decentralized/core/ethereum/worker.go
@@ -538,6 +538,11 @@ func (w *worker) buildTransactionTransferAction(ctx context.Context, task *sourc
 		return nil, fmt.Errorf("lookup token %s: %w", tokenAddress, err)
 	}
 
+	// If the token value is nil, set it to zero.
+	if tokenValue == nil {
+		tokenValue = big.NewInt(0)
+	}
+
 	tokenMetadata.Value = lo.ToPtr(decimal.NewFromBigInt(tokenValue, 0))
 
 	var actionType typex.TransactionType
@@ -572,6 +577,11 @@ func (w *worker) buildTransactionApprovalAction(ctx context.Context, task *sourc
 		return nil, fmt.Errorf("lookup token %s: %w", tokenAddress, err)
 	}
 
+	// If the token value is nil, set it to zero.
+	if tokenValue == nil {
+		tokenValue = big.NewInt(0)
+	}
+
 	tokenMetadata.Value = lo.ToPtr(decimal.NewFromBigInt(tokenValue, 0))
 
 	// Use the token value to determine the action type.
@@ -602,6 +612,11 @@ func (w *worker) buildCollectibleTransferAction(ctx context.Context, task *sourc
 	tokenMetadata, err := w.tokenClient.Lookup(ctx, uint64(chainID), &tokenAddress, tokenID, task.Header.Number)
 	if err != nil {
 		return nil, fmt.Errorf("lookup token %s: %w", tokenAddress, err)
+	}
+
+	// If the token value is nil, set it to zero.
+	if tokenValue == nil {
+		tokenValue = big.NewInt(0)
 	}
 
 	tokenMetadata.Value = lo.ToPtr(decimal.NewFromBigInt(tokenValue, 0))
@@ -672,6 +687,11 @@ func (w *worker) buildExchangeStakingVSLAction(ctx context.Context, task *source
 		return nil, fmt.Errorf("lookup token: %w", err)
 	}
 
+	// If the token value is nil, set it to zero.
+	if tokenValue == nil {
+		tokenValue = big.NewInt(0)
+	}
+
 	tokenMetadata.Value = lo.ToPtr(decimal.NewFromBigInt(tokenValue, 0))
 
 	action := activityx.Action{
@@ -695,6 +715,11 @@ func (w *worker) buildChipsMintAction(ctx context.Context, task *source.Task, fr
 		return nil, fmt.Errorf("lookup token metadata: %w", err)
 	}
 
+	// If the token value is nil, set it to zero.
+	if value == nil {
+		value = big.NewInt(0)
+	}
+
 	tokenMetadata.Value = lo.ToPtr(decimal.NewFromBigInt(value, 0))
 
 	return &activityx.Action{
@@ -710,6 +735,11 @@ func (w *worker) buildTransactionBridgeAction(ctx context.Context, chainID uint6
 	tokenMetadata, err := w.tokenClient.Lookup(ctx, chainID, tokenAddress, nil, blockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("lookup token %s: %w", tokenAddress, err)
+	}
+
+	// If the token value is nil, set it to zero.
+	if tokenValue == nil {
+		tokenValue = big.NewInt(0)
 	}
 
 	tokenMetadata.Value = lo.ToPtr(decimal.NewFromBigInt(tokenValue, 0))


### PR DESCRIPTION
## Summary
https://polygonscan.com/tx/0xda7953e0b756ddff528c1b9b74d0dff9f51298a6d8bdab8d592b76e9693d6a15#eventlog

In the transfer event log as shown in the link, a panic is triggered when the value is 0.

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [ ] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
