### PR TITLE
fix: update network configuration types for AI

### DIFF
--- a/internal/node/component/info/handler_network.go
+++ b/internal/node/component/info/handler_network.go
@@ -17,10 +17,10 @@ type NetworkConfigResponse struct {
 }
 
 type NetworkConfig struct {
-	RSS           NetworkConfigDetailForRSS `json:"rss,omitempty"`
-	Decentralized []NetworkConfigDetail     `json:"decentralized,omitempty"`
-	Federated     []NetworkConfigDetail     `json:"federated,omitempty"`
-	AI            []NetworkConfigDetail     `json:"ai,omitempty"`
+	RSS           NetworkConfigDetailForSingleWorker `json:"rss,omitempty"`
+	Decentralized []NetworkConfigDetail              `json:"decentralized,omitempty"`
+	Federated     []NetworkConfigDetail              `json:"federated,omitempty"`
+	AI            NetworkConfigDetailForSingleWorker `json:"ai,omitempty"`
 }
 
 type NetworkConfigDetail struct {
@@ -29,7 +29,7 @@ type NetworkConfigDetail struct {
 	WorkerConfig   []workerConfig `json:"worker_configs,omitempty"`
 }
 
-type NetworkConfigDetailForRSS struct {
+type NetworkConfigDetailForSingleWorker struct {
 	ID             string       `json:"id,omitempty"`
 	EndpointConfig *Endpoint    `json:"endpoint_configs,omitempty"`
 	WorkerConfig   workerConfig `json:"worker_configs,omitempty"`
@@ -45,7 +45,7 @@ func (c *Component) GetNetworkConfig(ctx echo.Context) error {
 		RSS:           getNetworkConfigDetailForRSS(network.RSSProtocol),
 		Decentralized: getNetworkConfigDetail(network.ArweaveProtocol, network.EthereumProtocol, network.FarcasterProtocol, network.NearProtocol),
 		Federated:     getNetworkConfigDetail(network.ActivityPubProtocol),
-		AI:            genAIConfigDetail(),
+		AI:            getNetworkConfigDetailForAI(),
 	}
 
 	zap.L().Debug("successfully retrieved network configuration")
@@ -55,10 +55,10 @@ func (c *Component) GetNetworkConfig(ctx echo.Context) error {
 	})
 }
 
-func getNetworkConfigDetailForRSS(protocol network.Protocol) NetworkConfigDetailForRSS {
+func getNetworkConfigDetailForRSS(protocol network.Protocol) NetworkConfigDetailForSingleWorker {
 	n := protocol.Networks()[0]
 
-	networkDetail := NetworkConfigDetailForRSS{
+	networkDetail := NetworkConfigDetailForSingleWorker{
 		ID: n.String(),
 	}
 

--- a/internal/node/component/info/network_config.go
+++ b/internal/node/component/info/network_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rss3-network/node/schema/worker/federated"
 	"github.com/rss3-network/node/schema/worker/rss"
 	"github.com/rss3-network/protocol-go/schema/network"
+	"go.uber.org/zap"
 )
 
 type ConfigDetailValueType string
@@ -614,15 +615,12 @@ var AIWorkerConfig = workerConfig{
 	},
 }
 
-// genAIConfigDetail generates the AI configuration details
-func genAIConfigDetail() []NetworkConfigDetail {
-	// Create an AI network detail with a fixed ID "agentdata"
-	networkDetail := NetworkConfigDetail{
-		ID:           "agentdata",
-		WorkerConfig: []workerConfig{},
+// getNetworkConfigDetailForAI generates the AI configuration details
+func getNetworkConfigDetailForAI() NetworkConfigDetailForSingleWorker {
+	networkDetail := NetworkConfigDetailForSingleWorker{
+		ID: "agentdata",
 	}
 
-	// Create the worker config by making a deep copy of the base config
 	workerConfig := deepCopyWorkerConfig(AIWorkerConfig)
 
 	workerConfig.Parameters = &Parameters{
@@ -702,8 +700,10 @@ func genAIConfigDetail() []NetworkConfigDetail {
 		},
 	}
 
-	// Add the worker config to the network detail
-	networkDetail.WorkerConfig = append(networkDetail.WorkerConfig, workerConfig)
+	networkDetail.WorkerConfig = workerConfig
 
-	return []NetworkConfigDetail{networkDetail}
+	zap.L().Debug("successfully retrieved AI network configuration details",
+		zap.String("networkID", "agentdata"))
+
+	return networkDetail
 }


### PR DESCRIPTION
## Summary

- Changed NetworkConfig structure to use NetworkConfigDetailForSingleWorker for both RSS and AI configurations.
- Updated the getNetworkConfigDetailForAI function to return a single worker configuration instead of a slice.
- Removed the genAIConfigDetail function as it was replaced by the new implementation for better clarity and efficiency.

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No