### PR TITLE
chore(deps): enable security updates only in dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    security_updates_only: true
     ignore:
       - dependency-name: "github.com/ethereum/go-ethereum"
       - dependency-name: "github.com/rss3-network/protocol-go"
@@ -13,8 +14,10 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    security_updates_only: true
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     target-branch: main
+    security_updates_only: true


### PR DESCRIPTION
## Summary

enable security updates only in dependabot 

## Checklist

- [x] The commit message follows [Angular Contributing guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit);
- [x] Tests for the changes have been added (for bug fixes / features);

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No